### PR TITLE
Fix map fly-to after omnibox parcel selection

### DIFF
--- a/src/components/zoning/ZoningLookupClient.tsx
+++ b/src/components/zoning/ZoningLookupClient.tsx
@@ -911,7 +911,20 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
         setSelectedParcel(null);
       }
       setMobileDrawerTab("parcel");
-      if (fly) setMapFlyTo({ id: bumpFlyId(), lng: fly.lng, lat: fly.lat, zoom: 16 });
+
+      let lng = fly?.lng;
+      let lat = fly?.lat;
+      if ((lng == null || lat == null || !Number.isFinite(lng) || !Number.isFinite(lat)) && match?.geometry) {
+        const c = centroidFromGeometry(match.geometry);
+        if (c) {
+          lng = c.lng;
+          lat = c.lat;
+        }
+      }
+      if (lng != null && lat != null && Number.isFinite(lng) && Number.isFinite(lat)) {
+        setMapFlyTo({ id: bumpFlyId(), lng, lat, zoom: 16 });
+      }
+
       if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
     },
     [features],

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -1122,23 +1122,44 @@ export function ZoningMap({
 
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !flyTo || !map.isStyleLoaded()) return;
-    if ("bounds" in flyTo) {
-      const { west, south, east, north } = flyTo.bounds;
-      map.fitBounds(
-        [
-          [west, south],
-          [east, north],
-        ],
-        { padding: { top: 72, bottom: 100, left: 40, right: 40 }, duration: 2000, maxZoom: 15 },
-      );
-    } else {
-      map.easeTo({
-        center: [flyTo.lng, flyTo.lat],
-        zoom: flyTo.zoom,
-        duration: 2000,
-      });
-    }
+    if (!map || !flyTo) return;
+
+    const apply = (): boolean => {
+      if (!map.isStyleLoaded()) return false;
+      if ("bounds" in flyTo) {
+        const { west, south, east, north } = flyTo.bounds;
+        map.fitBounds(
+          [
+            [west, south],
+            [east, north],
+          ],
+          { padding: { top: 72, bottom: 100, left: 40, right: 40 }, duration: 2000, maxZoom: 15 },
+        );
+      } else {
+        map.easeTo({
+          center: [flyTo.lng, flyTo.lat],
+          zoom: flyTo.zoom,
+          duration: 2000,
+        });
+      }
+      return true;
+    };
+
+    if (apply()) return undefined;
+
+    let done = false;
+    const onIdle = () => {
+      if (done) return;
+      if (apply()) {
+        done = true;
+        map.off("idle", onIdle);
+      }
+    };
+    map.on("idle", onIdle);
+    return () => {
+      done = true;
+      map.off("idle", onIdle);
+    };
   }, [flyTo]);
 
   if (!mapboxgl.accessToken) {


### PR DESCRIPTION
## Problem
Choosing a parcel from the map omnibox did not always move the camera: `flyTo` ran only when `map.isStyleLoaded()` was already true, so the effect often exited once and never retried.

## Changes
- **`ZoningMap.tsx`**: If the style is not ready, listen for `idle` and apply `easeTo` / `fitBounds` when `isStyleLoaded()` becomes true, then remove the listener.
- **`ZoningLookupClient.tsx`**: After omnibox parcel select, use omnibox `fly` coordinates when present; otherwise derive the target from the parcel feature centroid so we still navigate when coords are missing.

## How to verify
1. Open `/map`, open omnibox, pick a parcel result.
2. Map should ease to zoom 16 on the lot (including right after initial load).

Made with [Cursor](https://cursor.com)