### PR TITLE
Nav: Property Map CTA + assessor record on intel panel

### DIFF
--- a/src/components/map/PropertyIntelligencePanel.tsx
+++ b/src/components/map/PropertyIntelligencePanel.tsx
@@ -521,6 +521,17 @@ export function PropertyIntelligencePanel({
         </section>
 
         <div className="flex flex-col gap-2 border-t border-[var(--cedar-shingle)]/15 pt-3">
+          {selectedParcel?.internal_id ? (
+            <Button asChild variant="outline" className="w-full text-sm">
+              <a
+                href={`https://gis.vgsi.com/nantucketma/Parcel.aspx?Pid=${encodeURIComponent(String(selectedParcel.internal_id))}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View Assessor&apos;s Record
+              </a>
+            </Button>
+          ) : null}
           {selectedLink ? (
             <Button asChild className="w-full bg-blue-700 text-sm text-white hover:bg-blue-800">
               <a href={nantucketLinkListingUrl(selectedLink.linkId)} target="_blank" rel="noopener noreferrer">

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -107,14 +107,14 @@ export const NAV_STRUCTURE: Record<string, NavEntry> = {
 export const primaryNavItems: NavEntry[] = [
   NAV_STRUCTURE.marketPulse,
   NAV_STRUCTURE.neighborhoods,
-  NAV_STRUCTURE.propertyMap,
   NAV_STRUCTURE.resources,
   NAV_STRUCTURE.about,
 ];
 
+/** Primary header CTA (desktop + mobile). Opportunity desk routes stay live under /opportunities for deep links. */
 export const navCta = {
-  label: "Post an Opportunity",
-  path: "/opportunities",
+  label: "Property Map",
+  path: "/map",
 };
 
 // Compatibility exports for existing footer/sitemap consumers.


### PR DESCRIPTION
## Summary
Pauses the prominent **Post an Opportunity** header CTA in favor of **Property Map**, removes the redundant top-nav **Property Map** text link, and surfaces **View Assessor's Record** on the property map intelligence card.

## Changes
- **`src/lib/navigation.ts`**: `navCta` → **Property Map** → `/map`; drop `propertyMap` from `primaryNavItems` (still linked under Resources → Zoning & Planning Tools / mega menu).
- **`src/components/map/PropertyIntelligencePanel.tsx`**: Full-width outline button to VGSI `Parcel.aspx?Pid=` when `selectedParcel.internal_id` is set (same pattern as `ParcelDetailPanel`).

## Notes
- `/opportunities` and footer links to the Opportunity Desk are unchanged.

Made with [Cursor](https://cursor.com)