### PR TITLE
Omnibox & property map polish; Whale Watch LINK; nav mega menu; email & parcel pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "next-themes": "^0.4.6",
         "openai": "^4.104.0",
         "pdf-parse": "^1.1.1",
+        "polylabel": "^2.0.1",
         "react": "18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "18.3.1",
@@ -9489,6 +9490,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/polylabel": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-2.0.1.tgz",
+      "integrity": "sha512-B6Yu+Bdl/8SGtjVhyUfZzD3DwciCS9SPVtHiNdt8idHHatvTHp5Ss8XGDRmQFtfF1ZQnfK+Cj5dXdpkUXBbXgA==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^3.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "next-themes": "^0.4.6",
     "openai": "^4.104.0",
     "pdf-parse": "^1.1.1",
+    "polylabel": "^2.0.1",
     "react": "18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.3.1",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BarChart3, Eye, Handshake, Landmark, ShieldCheck, Users } from "lucide-react";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 export const metadata: Metadata = {
   title: "About | NantucketHouses.com",
@@ -92,7 +93,7 @@ export default function AboutPage() {
             Stephen Maury.
           </p>
           <a
-            href="https://calendly.com/stephen-maury/30min"
+            href={SCHEDULE_CALL_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex mt-6 brand-btn brand-btn-primary px-6 py-3 text-sm"
@@ -221,7 +222,7 @@ export default function AboutPage() {
                 Request a Custom Valuation Report
               </Link>
               <a
-                href="https://calendly.com/stephen-maury/30min"
+                href={SCHEDULE_CALL_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center justify-center bg-white/10 text-white px-5 py-2.5 rounded-md text-sm font-medium hover:bg-white/20 transition-colors"

--- a/src/app/affordable-housing/get-involved/page.tsx
+++ b/src/app/affordable-housing/get-involved/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Hammer, Heart, Home, Mail, ExternalLink } from "lucide-react";
 import { Breadcrumbs } from "@/components/regulatory/Breadcrumbs";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 const ways = [
   {
@@ -140,7 +141,7 @@ export default function GetInvolvedPage() {
               Submit to Opportunity Desk
             </Link>
             <a
-              href="https://calendly.com/stephen-maury/30min"
+              href={SCHEDULE_CALL_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block bg-white/10 text-white px-6 py-3 text-sm font-medium rounded-md hover:bg-white/20 transition-colors"

--- a/src/app/affordable-housing/page.tsx
+++ b/src/app/affordable-housing/page.tsx
@@ -5,6 +5,7 @@ import { FeaturedPartnerBanner } from "@/components/partners/FeaturedPartnerBann
 import housingData from "@/data/affordable-housing.json";
 import partnersData from "@/data/partners.json";
 import type { Partner } from "@/types";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 function formatCurrency(n: number): string {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(n);
@@ -258,7 +259,7 @@ export default function AffordableHousingPage() {
               Submit to Opportunity Desk
             </Link>
             <a
-              href="https://calendly.com/stephen-maury/30min"
+              href={SCHEDULE_CALL_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block bg-white/10 text-white px-6 py-3 text-sm font-medium rounded-md hover:bg-white/20 transition-colors"

--- a/src/app/api/map/omnibox/route.ts
+++ b/src/app/api/map/omnibox/route.ts
@@ -5,11 +5,13 @@ import type { Feature, Geometry } from "geojson";
 import { fetchListings, type CncListing } from "@/lib/cnc-api";
 import { centroidFromGeometry } from "@/lib/geo-centroid";
 import { MAP_NEIGHBORHOOD_BOUNDS } from "@/lib/map-neighborhood-bounds";
+import { listingAddressStem, looksLikeStreetAddress, streetMatchKey } from "@/lib/address-street-key";
 import type {
   OmniboxActiveListing,
   OmniboxCategories,
   OmniboxNeighborhoodHit,
   OmniboxParcelHit,
+  OmniboxParcelListingMatch,
   OmniboxResponse,
   OmniboxRentalHit,
   OmniboxSoldComp,
@@ -140,6 +142,89 @@ function pointInBbox(lng: number, lat: number, b: { west: number; south: number;
   return lng >= b.west && lng <= b.east && lat >= b.south && lat <= b.north;
 }
 
+function parcelIdFromStreetLine(
+  streetLine: string,
+  streetIndex: Map<string, { lng: number; lat: number; parcel_id: string }>,
+): string | null {
+  const stem = listingAddressStem(streetLine);
+  if (!stem || !looksLikeStreetAddress(stem)) return null;
+  const key = streetMatchKey(stem);
+  if (!key) return null;
+  const hit = streetIndex.get(key);
+  return hit ? String(hit.parcel_id).trim() : null;
+}
+
+const LISTING_KIND_RANK: Record<OmniboxParcelListingMatch["kind"], number> = {
+  link_active: 3,
+  link_sold: 2,
+  rental: 1,
+};
+
+/**
+ * Attach LINK / rental stats to parcel rows that appear in omnibox results; drop duplicate
+ * listing/rental rows that map to the same assessor parcel_id.
+ */
+function mergeListingsIntoParcels(
+  parcels: OmniboxParcelHit[],
+  active: OmniboxActiveListing[],
+  sold: OmniboxSoldComp[],
+  rentals: OmniboxRentalHit[],
+): {
+  activeListings: OmniboxActiveListing[];
+  soldComps: OmniboxSoldComp[];
+  rentals: OmniboxRentalHit[];
+} {
+  const parcelIds = new Set(parcels.map((p) => p.parcel_id));
+
+  const consider = (pid: string | null | undefined, m: OmniboxParcelListingMatch): void => {
+    if (!pid || !parcelIds.has(pid)) return;
+    const parcel = parcels.find((x) => x.parcel_id === pid);
+    if (!parcel) return;
+    const cur = parcel.matchedListing;
+    if (!cur || LISTING_KIND_RANK[m.kind] > LISTING_KIND_RANK[cur.kind]) {
+      parcel.matchedListing = m;
+    }
+  };
+
+  for (const l of active) {
+    if (l.parcelId) {
+      consider(l.parcelId, {
+        kind: "link_active",
+        linkId: l.id,
+        priceLabel: l.priceLabel,
+        statusLabel: "Active · LINK",
+      });
+    }
+  }
+  for (const l of sold) {
+    if (l.parcelId) {
+      consider(l.parcelId, {
+        kind: "link_sold",
+        linkId: l.id,
+        priceLabel: l.priceLabel,
+        statusLabel: "Sold · LINK",
+      });
+    }
+  }
+  for (const r of rentals) {
+    if (r.parcelId) {
+      consider(r.parcelId, {
+        kind: "rental",
+        nrPropertyId: r.nrPropertyId,
+        rentalSlug: r.slug ?? null,
+        priceLabel: r.priceLabel ?? "—",
+        statusLabel: "Vacation rental",
+      });
+    }
+  }
+
+  return {
+    activeListings: active.filter((l) => !l.parcelId || !parcelIds.has(l.parcelId)),
+    soldComps: sold.filter((l) => !l.parcelId || !parcelIds.has(l.parcelId)),
+    rentals: rentals.filter((r) => !r.parcelId || !parcelIds.has(r.parcelId)),
+  };
+}
+
 function buildCategories(o: {
   activeListings: OmniboxActiveListing[];
   soldComps: OmniboxSoldComp[];
@@ -168,11 +253,14 @@ function buildCategories(o: {
     parcels: o.parcels.map((p) => ({
       id: p.parcel_id,
       type: "parcel" as const,
-      label: `${p.address} • ${p.taxMap}-${p.parcel}`,
+      label: p.matchedListing
+        ? `${p.address} • ${p.matchedListing.statusLabel} · ${p.matchedListing.priceLabel}`
+        : `${p.address} • ${p.taxMap}-${p.parcel}`,
       zone: p.zone ?? "—",
       expansionVerdict: p.expansionVerdict ?? null,
       lat: p.lat,
       lng: p.lng,
+      matchedListing: p.matchedListing ?? null,
     })),
     neighborhoods: o.neighborhoods.map((n) => ({
       id: n.slug,
@@ -340,6 +428,7 @@ export async function GET(request: Request) {
         priceLabel: formatMoney(row.ListPrice ?? pt.listPrice),
         lat: pt.latitude,
         lng: pt.longitude,
+        parcelId: pt.parcel_id,
         source: "LINK",
         status: "for_sale",
       });
@@ -358,6 +447,7 @@ export async function GET(request: Request) {
         closeDate: row.CloseDate ?? null,
         lat: pt.latitude,
         lng: pt.longitude,
+        parcelId: pt.parcel_id,
         source: "LINK",
         status: "sold",
       });
@@ -379,14 +469,16 @@ export async function GET(request: Request) {
           if (id == null || lat == null || lng == null) continue;
           const wk = Math.max(0, ...(row.NrRentalRates?.map((r) => r.propertyWeeklyRentInteger ?? 0) ?? []));
           const weekly = wk > 0 ? wk : row.averageNightlyRate ? Math.round(row.averageNightlyRate * 7) : null;
+          const addrLine = String(row.streetAddress ?? "").trim() || "Rental";
           rentals.push({
             nrPropertyId: id,
             slug: row.slug?.trim() || null,
-            address: String(row.streetAddress ?? "").trim() || "Rental",
+            address: addrLine,
             headline: String(row.headline ?? "").trim(),
             priceLabel: weekly ? `${formatMoney(weekly)}/wk est.` : null,
             lat,
             lng,
+            parcelId: parcelIdFromStreetLine(addrLine, index),
           });
           if (rentals.length >= 10) break;
         }
@@ -395,17 +487,29 @@ export async function GET(request: Request) {
       }
     }
 
-    const categories = buildCategories({ activeListings, soldComps, parcels, neighborhoods });
+    const { activeListings: mergedActive, soldComps: mergedSold, rentals: mergedRentals } = mergeListingsIntoParcels(
+      parcels,
+      activeListings,
+      soldComps,
+      rentals,
+    );
+
+    const categories = buildCategories({
+      activeListings: mergedActive,
+      soldComps: mergedSold,
+      parcels,
+      neighborhoods,
+    });
 
     const out: OmniboxResponse = {
       query: q,
       suggestions: nlSuggestions,
       categories,
-      activeListings,
-      soldComps,
+      activeListings: mergedActive,
+      soldComps: mergedSold,
       parcels,
       neighborhoods,
-      rentals,
+      rentals: mergedRentals,
       nlSuggestions: NL_SUGGESTIONS,
     };
 

--- a/src/app/api/opportunities/route.ts
+++ b/src/app/api/opportunities/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
           },
           body: JSON.stringify({
             from: "NantucketHouses.com <notifications@nantuckethouses.com>",
-            to: "stephen@nantuckethouses.com",
+            to: "stephen@maury.net",
             subject: `New Opportunity: ${categoryLabel(category)} from ${name}`,
             html: `
               <h2>New ${categoryLabel(category)} Submission</h2>

--- a/src/app/api/whale-watch/route.ts
+++ b/src/app/api/whale-watch/route.ts
@@ -32,6 +32,8 @@ export async function GET() {
         listPrice: l.ListPrice,
         closeDate: l.CloseDate!,
         neighborhood: l.MLSAreaMajor ?? "Unknown",
+        linkListingId:
+          l.link_id != null && l.link_id > 0 ? String(l.link_id) : undefined,
       }));
 
     return NextResponse.json({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
 
+/* shadcn/ui primitives use bg-popover / text-popover-foreground — define tokens or panels render transparent */
+@theme {
+  --color-popover: #ffffff;
+  --color-popover-foreground: #074059;
+}
+
 @layer base {
   :root {
     /* Shared NR brand palette (aligned with nr-web-fe) */

--- a/src/app/market-pulse/page.tsx
+++ b/src/app/market-pulse/page.tsx
@@ -10,6 +10,7 @@ import { PriceDistributionChart } from "@/components/charts/PriceDistributionCha
 import { NeighborhoodSalesTable } from "@/components/charts/NeighborhoodSalesTable";
 import { WhaleWatch } from "@/components/home/WhaleWatch";
 import type { WhaleWatchSale } from "@/types";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 type MonthlyData = {
   month: string;
@@ -285,7 +286,7 @@ export default function MarketPulsePage() {
             neighborhood, price point, or development plans — let&apos;s talk.
           </p>
           <a
-            href="https://calendly.com/stephen-maury/30min"
+            href={SCHEDULE_CALL_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block bg-[var(--privet-green)] text-white px-8 py-3 text-sm font-medium rounded-md hover:bg-[var(--privet-green)]/90 transition-colors"

--- a/src/app/market-pulse/price-trends/page.tsx
+++ b/src/app/market-pulse/price-trends/page.tsx
@@ -511,7 +511,7 @@ export default function PriceTrendsPage() {
                 Request Custom Valuation
               </Link>
               <a
-                href="mailto:stephen@nantuckethouses.com?subject=Download%20Full%20Q1%202026%20Report"
+                href="mailto:stephen@maury.net?subject=Download%20Full%20Q1%202026%20Report"
                 className="inline-flex items-center justify-center bg-white/10 text-white px-5 py-2.5 rounded-md text-sm font-medium hover:bg-white/20 transition-colors"
               >
                 Download Full Q1 2026 Report

--- a/src/app/market-pulse/whale-watch/page.tsx
+++ b/src/app/market-pulse/whale-watch/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Breadcrumbs } from "@/components/regulatory/Breadcrumbs";
 import { CTASection } from "@/components/home/CTASection";
 import { fetchAllListings } from "@/lib/cnc-api";
+import { WhaleWatchSaleAddress } from "@/components/home/WhaleWatch";
 import type { WhaleWatchSale } from "@/types";
 
 export const metadata: Metadata = {
@@ -68,6 +69,8 @@ async function getWhaleWatchData(): Promise<WhaleWatchStats> {
         listPrice: l.ListPrice,
         closeDate: l.CloseDate!,
         neighborhood: l.MLSAreaMajor ?? "Unknown",
+        linkListingId:
+          l.link_id != null && l.link_id > 0 ? String(l.link_id) : undefined,
       }));
 
     const totalVolume = all.reduce((sum, s) => sum + s.closePrice, 0);
@@ -151,7 +154,14 @@ export default async function WhaleWatchPage() {
                 {highestSale ? formatCurrency(highestSale.closePrice) : "—"}
               </p>
               <p className="text-sm text-[var(--nantucket-gray)] mt-1">
-                {highestSale ? highestSale.address : "No sales data yet"}
+                {highestSale ? (
+                  <WhaleWatchSaleAddress
+                    sale={highestSale}
+                    className="font-medium text-[var(--nantucket-gray)]"
+                  />
+                ) : (
+                  "No sales data yet"
+                )}
               </p>
             </div>
           </div>
@@ -211,7 +221,7 @@ export default async function WhaleWatchPage() {
                           </span>
                         </td>
                         <td className="px-4 py-3 font-medium text-[var(--atlantic-navy)]">
-                          {sale.address}
+                          <WhaleWatchSaleAddress sale={sale} />
                         </td>
                         <td className="px-4 py-3 text-[var(--nantucket-gray)] hidden md:table-cell">
                           {sale.neighborhood}

--- a/src/app/neighborhoods/[slug]/page.tsx
+++ b/src/app/neighborhoods/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumbs } from "@/components/regulatory/Breadcrumbs";
 import { NEIGHBORHOOD_SLUGS, getNeighborhoodName } from "@/lib/neighborhoods";
 import neighborhoodProfiles from "@/data/neighborhood-profiles.json";
 import zoningData from "@/data/zoning-districts.json";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 type Profile = {
   slug: string;
@@ -209,7 +210,7 @@ export default async function NeighborhoodPage({ params }: Props) {
               Submit Buying Criteria
             </Link>
             <a
-              href="https://calendly.com/stephen-maury/30min"
+              href={SCHEDULE_CALL_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block bg-white/10 text-white px-6 py-3 text-sm font-medium rounded-md hover:bg-white/20 transition-colors"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,8 @@ async function getWhaleWatchSales(): Promise<WhaleWatchSale[]> {
         listPrice: l.ListPrice,
         closeDate: l.CloseDate!,
         neighborhood: l.MLSAreaMajor ?? "Unknown",
+        linkListingId:
+          l.link_id != null && l.link_id > 0 ? String(l.link_id) : undefined,
       }));
   } catch (error) {
     console.error("Failed to fetch whale watch:", error);

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -60,7 +60,7 @@ export default function PrivacyPage() {
             <div>
               <h2 className="text-base text-[var(--atlantic-navy)] font-semibold mb-2">Contact</h2>
               <p>
-                For privacy-related questions, contact <a className="text-[var(--privet-green)] hover:underline" href="mailto:stephen@nantuckethouses.com">stephen@nantuckethouses.com</a>.
+                For privacy-related questions, contact <a className="text-[var(--privet-green)] hover:underline" href="mailto:stephen@maury.net">stephen@maury.net</a>.
               </p>
             </div>
           </div>

--- a/src/app/regulatory/page.tsx
+++ b/src/app/regulatory/page.tsx
@@ -116,9 +116,7 @@ export default async function RegulatoryHubPage() {
             viability — zoning constraints, HDC likelihood, and timeline expectations.
           </p>
           <a
-            href="https://calendly.com/stephen-maury/gut-check"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="mailto:stephen@maury.net?subject=Project%20Feasibility%20Gut%20Check"
             className="inline-block bg-[var(--privet-green)] text-white px-8 py-3 text-sm font-medium rounded-md hover:bg-[var(--privet-green)]/90 transition-colors"
           >
             Project Feasibility Gut Check

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -130,7 +130,7 @@ export default async function ResourcesPage() {
               Join early access for a Nantucket-specific build and renovation calculator with local assumptions.
             </p>
             <a
-              href="mailto:stephen@nantuckethouses.com?subject=Cost%20Calculator%20Beta%20Early%20Access"
+              href="mailto:stephen@maury.net?subject=Cost%20Calculator%20Beta%20Early%20Access"
               className="inline-flex items-center gap-2 brand-btn brand-btn-primary px-5 py-2.5 text-sm"
             >
               Join Early Access

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -60,7 +60,7 @@ export default function TermsPage() {
             <div>
               <h2 className="text-base text-[var(--atlantic-navy)] font-semibold mb-2">Contact</h2>
               <p>
-                Questions about these terms can be sent to <a className="text-[var(--privet-green)] hover:underline" href="mailto:stephen@nantuckethouses.com">stephen@nantuckethouses.com</a>.
+                Questions about these terms can be sent to <a className="text-[var(--privet-green)] hover:underline" href="mailto:stephen@maury.net">stephen@maury.net</a>.
               </p>
             </div>
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,7 +44,7 @@ export function Footer() {
                 <Linkedin className="w-4 h-4" />
               </a>
               <a
-                href="mailto:stephen@nantuckethouses.com"
+                href="mailto:stephen@maury.net"
                 className="p-2 rounded-md bg-white/10 hover:bg-[var(--privet-green)] transition-colors"
                 aria-label="Email"
               >
@@ -138,8 +138,8 @@ export function Footer() {
                 </a>
               </li>
               <li>
-                <a href="mailto:stephen@nantuckethouses.com" className="hover:text-white transition-colors">
-                  stephen@nantuckethouses.com
+                <a href="mailto:stephen@maury.net" className="hover:text-white transition-colors">
+                  stephen@maury.net
                 </a>
               </li>
             </ul>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Instagram, Linkedin, Mail } from "lucide-react";
 import { navPillars, standaloneNavItems } from "@/lib/navigation";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
@@ -143,7 +144,7 @@ export function Footer() {
               </li>
             </ul>
             <a
-              href="https://calendly.com/stephen-maury/30min"
+              href={SCHEDULE_CALL_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block mt-4 bg-[var(--privet-green)] text-white px-5 py-2.5 text-sm font-medium rounded-md hover:bg-[var(--privet-green)]/90 transition-colors"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -57,43 +57,46 @@ export function Navigation() {
                     <ChevronDown className="w-3 h-3 opacity-50 transition-transform group-hover:rotate-180" />
                   </button>
 
-                  <div className="absolute top-full left-0 pt-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                    <div className={`bg-white rounded-lg border border-[#e8e8e8] shadow-lg p-3 ${
-                      item.megaMenuColumns ? "min-w-[1040px]" : "min-w-[260px]"
-                    }`}>
-                      {item.megaMenuColumns ? (
-                        <>
+                  {item.megaMenuColumns ? (
+                    <>
+                      {/* Full-width hover bridge so cursor can reach the fixed mega without leaving the group */}
+                      <div
+                        aria-hidden
+                        className="pointer-events-none absolute left-1/2 top-full z-[55] h-4 w-screen max-w-[100vw] -translate-x-1/2 opacity-0 invisible transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:visible"
+                      />
+                      <div className="pointer-events-none fixed inset-x-4 top-16 z-[60] flex justify-center pt-2 opacity-0 invisible transition-all duration-200 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:visible lg:top-20">
+                        <div className="max-h-[min(80vh,calc(100vh-6rem))] w-full max-w-[1040px] min-w-0 overflow-y-auto rounded-lg border border-[#e8e8e8] bg-white p-3 shadow-lg">
                           <div
-                            className="grid gap-4"
+                            className="grid min-w-0 gap-4"
                             style={{
                               gridTemplateColumns: `repeat(${item.megaMenuColumns.length}, minmax(0, 1fr))`,
                             }}
                           >
                             {item.megaMenuColumns.map((column) => (
-                              <div key={column.label}>
-                                <p className="text-xs font-semibold uppercase tracking-wider text-[var(--nantucket-gray)] mb-2 font-sans">
+                              <div key={column.label} className="min-w-0">
+                                <p className="mb-2 font-sans text-xs font-semibold uppercase tracking-wider text-[var(--nantucket-gray)]">
                                   {column.label}
                                 </p>
                                 <div className="space-y-1">
-                                  {column.items.map((subItem) => (
+                                  {column.items.map((subItem) =>
                                     subItem.path ? (
                                       <Link
                                         key={`${column.label}-${subItem.path}-${subItem.label}`}
                                         href={subItem.path}
-                                        className={`block px-3 py-2.5 rounded-md text-sm transition-colors ${
+                                        className={`block rounded-md px-3 py-2.5 text-sm transition-colors ${
                                           pathname === subItem.path
-                                            ? "text-[var(--privet-green)] bg-[var(--sandstone)]"
+                                            ? "bg-[var(--sandstone)] text-[var(--privet-green)]"
                                             : "text-[var(--atlantic-navy)] hover:bg-[var(--sandstone)]/60"
                                         } ${subItem.isFeatured ? "border border-[var(--privet-green)]/30" : ""}`}
                                       >
                                         <span className="font-medium">{subItem.label}</span>
                                         {subItem.badge && (
-                                          <span className="ml-2 inline-flex rounded-full bg-[var(--privet-green)]/10 text-[var(--privet-green)] px-2 py-0.5 text-[10px] font-semibold align-middle">
+                                          <span className="ml-2 inline-flex rounded-full bg-[var(--privet-green)]/10 px-2 py-0.5 align-middle text-[10px] font-semibold text-[var(--privet-green)]">
                                             {subItem.badge}
                                           </span>
                                         )}
                                         {subItem.description && (
-                                          <span className="block text-xs text-[var(--nantucket-gray)] mt-0.5">
+                                          <span className="mt-0.5 block text-xs text-[var(--nantucket-gray)]">
                                             {subItem.description}
                                           </span>
                                         )}
@@ -101,54 +104,58 @@ export function Navigation() {
                                     ) : (
                                       <div
                                         key={`${column.label}-nolink-${subItem.label}`}
-                                        className={`block px-3 py-2.5 rounded-md text-sm ${
+                                        className={`block rounded-md px-3 py-2.5 text-sm ${
                                           subItem.label.includes("Cost Calculator")
-                                            ? "text-[var(--privet-green)] bg-[var(--sandstone)]/75"
-                                            : "text-[var(--atlantic-navy)]/75 bg-[var(--sandstone)]/40"
+                                            ? "bg-[var(--sandstone)]/75 text-[var(--privet-green)]"
+                                            : "bg-[var(--sandstone)]/40 text-[var(--atlantic-navy)]/75"
                                         }`}
                                       >
                                         <span className="font-medium">{subItem.label}</span>
                                         {subItem.badge && (
-                                          <span className="ml-2 inline-flex rounded-full bg-[var(--privet-green)]/10 text-[var(--privet-green)] px-2 py-0.5 text-[10px] font-semibold align-middle">
+                                          <span className="ml-2 inline-flex rounded-full bg-[var(--privet-green)]/10 px-2 py-0.5 align-middle text-[10px] font-semibold text-[var(--privet-green)]">
                                             {subItem.badge}
                                           </span>
                                         )}
                                         {subItem.description && (
-                                          <span className="block text-xs text-[var(--nantucket-gray)] mt-0.5">
+                                          <span className="mt-0.5 block text-xs text-[var(--nantucket-gray)]">
                                             {subItem.description}
                                           </span>
                                         )}
                                       </div>
-                                    )
-                                  ))}
+                                    ),
+                                  )}
                                 </div>
                               </div>
                             ))}
                           </div>
-                          <div className="mt-3 pt-3 border-t border-[#e8e8e8]">
+                          <div className="mt-3 border-t border-[#e8e8e8] pt-3">
                             <Link
                               href={item.path}
-                              className="inline-flex items-center bg-[var(--atlantic-navy)] text-white px-4 py-2 text-sm font-medium rounded-md hover:bg-[var(--atlantic-navy)]/90 transition-colors"
+                              className="inline-flex items-center rounded-md bg-[var(--atlantic-navy)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--atlantic-navy)]/90"
                             >
                               Explore All Resources
                             </Link>
                           </div>
-                        </>
-                      ) : (
-                        item.children?.map((subItem) =>
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="absolute left-0 top-full z-50 max-w-[calc(100vw-1.5rem)] pt-2 opacity-0 invisible transition-all duration-200 group-hover:opacity-100 group-hover:visible">
+                      <div className="min-w-[260px] w-max max-w-full rounded-lg border border-[#e8e8e8] bg-white p-3 shadow-lg">
+                        {item.children?.map((subItem) =>
                           subItem.path ? (
                             <Link
                               key={subItem.path}
                               href={subItem.path}
-                              className={`block px-3 py-2.5 rounded-md text-sm transition-colors ${
+                              className={`block rounded-md px-3 py-2.5 text-sm transition-colors ${
                                 pathname === subItem.path
-                                  ? "text-[var(--privet-green)] bg-[var(--sandstone)]"
+                                  ? "bg-[var(--sandstone)] text-[var(--privet-green)]"
                                   : "text-[var(--atlantic-navy)] hover:bg-[var(--sandstone)]/60"
                               }`}
                             >
                               <span className="font-medium">{subItem.label}</span>
                               {subItem.description && (
-                                <span className="block text-xs text-[var(--nantucket-gray)] mt-0.5">
+                                <span className="mt-0.5 block text-xs text-[var(--nantucket-gray)]">
                                   {subItem.description}
                                 </span>
                               )}
@@ -156,20 +163,20 @@ export function Navigation() {
                           ) : (
                             <div
                               key={`nolink-${item.key}-${subItem.label}`}
-                              className="block px-3 py-2.5 rounded-md text-sm text-[var(--atlantic-navy)]/70 bg-[var(--sandstone)]/40"
+                              className="block rounded-md bg-[var(--sandstone)]/40 px-3 py-2.5 text-sm text-[var(--atlantic-navy)]/70"
                             >
                               <span className="font-medium">{subItem.label}</span>
                               {subItem.description && (
-                                <span className="block text-xs text-[var(--nantucket-gray)] mt-0.5">
+                                <span className="mt-0.5 block text-xs text-[var(--nantucket-gray)]">
                                   {subItem.description}
                                 </span>
                               )}
                             </div>
                           ),
-                        )
-                      )}
+                        )}
+                      </div>
                     </div>
-                  </div>
+                  )}
                 </div>
               );
             })}

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -26,7 +26,7 @@ export function StructuredData() {
       addressCountry: "US",
     },
     telephone: "+1-508-451-0191",
-    email: "stephen@nantuckethouses.com",
+    email: "stephen@maury.net",
     areaServed: {
       "@type": "City",
       name: "Nantucket",

--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -24,9 +24,7 @@ export function CTASection() {
             Talk to Stephen
           </a>
           <a
-            href="https://calendly.com/stephen-maury/gut-check"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="mailto:stephen@maury.net?subject=Project%20Feasibility%20Gut%20Check"
             className="inline-flex items-center gap-2 brand-btn brand-btn-secondary px-8 py-4 text-sm"
           >
             <ClipboardCheck className="w-4 h-4" />

--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -1,4 +1,5 @@
 import { Phone, ClipboardCheck } from "lucide-react";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 export function CTASection() {
   return (
@@ -14,7 +15,7 @@ export function CTASection() {
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
           <a
-            href="https://calendly.com/stephen-maury/30min"
+            href={SCHEDULE_CALL_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 brand-btn brand-btn-primary px-8 py-4 text-sm"

--- a/src/components/home/NewsletterSignup.tsx
+++ b/src/components/home/NewsletterSignup.tsx
@@ -109,7 +109,7 @@ export function NewsletterSignup() {
 
         {status === "error" && (
           <p className="mt-3 text-xs text-red-400">
-            Something went wrong. Please try again or email stephen@nantuckethouses.com directly.
+            Something went wrong. Please try again or email stephen@maury.net directly.
           </p>
         )}
       </div>

--- a/src/components/home/WhaleWatch.tsx
+++ b/src/components/home/WhaleWatch.tsx
@@ -1,9 +1,40 @@
 import type { WhaleWatchSale } from "@/types";
+import { nantucketLinkListingUrl } from "@/lib/link-listing-url";
 
 type Props = {
   sales: WhaleWatchSale[];
   year: number;
 };
+
+/** Linked row: underline + hover; text color comes from `className` or defaults to Atlantic navy. */
+const linkAffordance =
+  "underline decoration-[var(--cedar-shingle)]/50 underline-offset-2 hover:text-[var(--privet-green)] hover:decoration-[var(--privet-green)]/50";
+
+/** Renders the street address; when `linkListingId` is set, links to the public LINK listing page. */
+export function WhaleWatchSaleAddress({
+  sale,
+  className,
+}: {
+  sale: WhaleWatchSale;
+  className?: string;
+}) {
+  if (sale.linkListingId) {
+    const merged = [linkAffordance, className ?? "font-medium text-[var(--atlantic-navy)]"]
+      .filter(Boolean)
+      .join(" ");
+    return (
+      <a
+        href={nantucketLinkListingUrl(sale.linkListingId)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={merged}
+      >
+        {sale.address}
+      </a>
+    );
+  }
+  return <span className={className}>{sale.address}</span>;
+}
 
 function formatCurrency(value: number): string {
   if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
@@ -66,7 +97,7 @@ export function WhaleWatch({ sales, year }: Props) {
                     </span>
                   </td>
                   <td className="px-4 py-3 font-medium text-[var(--atlantic-navy)]">
-                    {sale.address}
+                    <WhaleWatchSaleAddress sale={sale} />
                   </td>
                   <td className="px-4 py-3 text-[var(--nantucket-gray)]">
                     {sale.neighborhood}

--- a/src/components/map/MapOmnibox.tsx
+++ b/src/components/map/MapOmnibox.tsx
@@ -356,6 +356,11 @@ export function MapOmnibox({
                             {p.zone ? ` · ${p.zone}` : ""}
                             {p.expansionVerdict ? ` · ${p.expansionVerdict}` : ""}
                           </p>
+                          {p.matchedListing ? (
+                            <p className="mt-0.5 text-xs font-medium text-[var(--atlantic-navy)]">
+                              {p.matchedListing.statusLabel} · {p.matchedListing.priceLabel}
+                            </p>
+                          ) : null}
                         </div>
                       </CommandItem>
                     ))}

--- a/src/components/map/MapOmnibox.tsx
+++ b/src/components/map/MapOmnibox.tsx
@@ -8,6 +8,7 @@ import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { cn } from "@/components/ui/utils";
 import type { PropertyMapMode } from "@/lib/property-map-filters";
 import type { OmniboxActiveListing, OmniboxResponse, OmniboxRentalHit, OmniboxSoldComp } from "@/lib/map-omnibox-types";
+import { formatLinkMlsDateDisplay } from "@/lib/link-listing-date-format";
 import { pushRecentOmniboxSearch, readRecentOmniboxSearches, type OmniboxRecentEntry } from "@/lib/omnibox-local-storage";
 
 const SLASH_HINT_KEY = "nh-map-omnibox-slash-hint-dismissed";
@@ -439,7 +440,7 @@ export function MapOmnibox({
                   </CommandGroup>
                 ) : null}
                 {data.soldComps.length ? (
-                  <CommandGroup heading="LINK — Sold" className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:uppercase">
+                  <CommandGroup heading="Sold Listings" className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:uppercase">
                     {data.soldComps.map((l) => (
                       <CommandItem
                         key={l.id}
@@ -461,7 +462,7 @@ export function MapOmnibox({
                           <p className="text-sm font-medium text-[var(--atlantic-navy)]">{l.address}</p>
                           <p className="text-xs text-[var(--nantucket-gray)]">
                             {l.priceLabel}
-                            {l.closeDate ? ` · ${l.closeDate}` : ""}
+                            {l.closeDate ? ` · ${formatLinkMlsDateDisplay(l.closeDate)}` : ""}
                           </p>
                         </div>
                       </CommandItem>

--- a/src/components/map/MapResearchHubStickyFooter.tsx
+++ b/src/components/map/MapResearchHubStickyFooter.tsx
@@ -32,11 +32,11 @@ export function MapResearchHubStickyFooter({ className }: Props) {
           ·
         </span>
         <a
-          href="mailto:stephen@nantuckethouses.com"
+          href="mailto:stephen@maury.net"
           className="inline-flex min-h-10 max-w-full items-center rounded-md px-2 underline-offset-2 hover:underline"
-          aria-label="Email stephen@nantuckethouses.com"
+          aria-label="Email stephen@maury.net"
         >
-          stephen@nantuckethouses.com
+          stephen@maury.net
         </a>
       </p>
       <nav

--- a/src/components/map/MapResearchHubStickyFooter.tsx
+++ b/src/components/map/MapResearchHubStickyFooter.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link";
 import { cn } from "@/components/ui/utils";
-
-const CALENDLY_URL = "https://calendly.com/stephen-maury/30min";
+import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 type Props = {
   className?: string;
@@ -14,7 +13,7 @@ export function MapResearchHubStickyFooter({ className }: Props) {
   return (
     <div className={cn("shrink-0 space-y-2", className)}>
       <a
-        href={CALENDLY_URL}
+        href={SCHEDULE_CALL_URL}
         target="_blank"
         rel="noopener noreferrer"
         className="flex w-full items-center justify-center rounded-md bg-[var(--privet-green)] px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[var(--brass-hover)]"

--- a/src/components/map/PropertyIntelligencePanel.tsx
+++ b/src/components/map/PropertyIntelligencePanel.tsx
@@ -52,15 +52,13 @@ function linkMlsNeighborhood(mlsArea: string | null | undefined): string | null 
 function rentalPulseRows(listPrice: number | null, weeklyRent: number | null) {
   const peak = weeklyRent ?? (listPrice != null && listPrice > 0 ? Math.max(8000, Math.round(listPrice * 0.0011)) : null);
   if (peak == null) return null;
-  const lowW = 18;
-  const highW = 26;
-  const annualLow = Math.round(peak * lowW * 0.92);
-  const annualHigh = Math.round(peak * highW * 1.05);
+  /** Rule of thumb: ~10 peak summer weeks of gross rent (simplified annual revenue). */
+  const annualRevenue = Math.round(peak * 10);
   const cap =
     listPrice != null && listPrice > 0
-      ? `${(((annualLow + annualHigh) / 2 / listPrice) * 100).toFixed(1)}% (at list)`
+      ? `${((annualRevenue / listPrice) * 100).toFixed(1)}% (at list)`
       : "—";
-  return { peak, annualLow, annualHigh, cap };
+  return { peak, annualRevenue, cap };
 }
 
 function buildTimeline(link: LinkListingPinProperties | null): TimelineEntry[] {
@@ -434,9 +432,7 @@ export function PropertyIntelligencePanel({
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-[var(--nantucket-gray)]">Est. annual revenue</dt>
-                <dd className="font-medium text-[var(--atlantic-navy)]">
-                  {formatMoney(rentalPulse.annualLow)}–{formatMoney(rentalPulse.annualHigh)}
-                </dd>
+                <dd className="font-medium text-[var(--atlantic-navy)]">{formatMoney(rentalPulse.annualRevenue)}</dd>
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-[var(--nantucket-gray)]">Est. cap rate</dt>
@@ -565,8 +561,9 @@ export function PropertyIntelligencePanel({
               href={`mailto:stephen@nantuckethouses.com?subject=${encodeURIComponent(`Property: ${title} — valuation / tour`)}`}
               target="_blank"
               rel="noopener noreferrer"
+              title="Custom valuation or property tour — opens your email app"
             >
-              Message Stephen — custom valuation / tour
+              Message Stephen
             </a>
           </Button>
         </div>

--- a/src/components/map/PropertyIntelligencePanel.tsx
+++ b/src/components/map/PropertyIntelligencePanel.tsx
@@ -3,13 +3,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Info } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/components/ui/utils";
 import type { ParcelProperties } from "@/components/zoning/ZoningMap";
 import type { LinkListingPinProperties, ParcelMapLinkListingMatch } from "@/lib/link-listings-parcel-match";
 import type { NrMapRentalResult } from "@/lib/nr-map-rentals";
 import { nantucketLinkListingUrl } from "@/lib/link-listing-url";
+import { formatLinkMlsDateDisplay } from "@/lib/link-listing-date-format";
 import { nantucketVacationRentalListingUrl } from "@/lib/nr-vacation-rental-url";
 import {
   formatExpansionIdea,
@@ -64,8 +65,10 @@ function rentalPulseRows(listPrice: number | null, weeklyRent: number | null) {
 function buildTimeline(link: LinkListingPinProperties | null): TimelineEntry[] {
   const out: TimelineEntry[] = [];
   if (link?.pool === "sold" && link.closeDate) {
-    const y = String(link.closeDate).slice(0, 4);
-    out.push({ year: y || "—", label: `Sold — ${link.closePrice || link.listPrice || "price on file"}` });
+    out.push({
+      year: formatLinkMlsDateDisplay(link.closeDate) || "—",
+      label: `Sold — ${link.closePrice || link.listPrice || "price on file"}`,
+    });
   }
   out.push({ year: "—", label: "HDC / permit history: request a pulled file from Stephen for this parcel." });
   out.push({ year: "—", label: "Rental history: peak weeks and rate cards available on comparable corridor homes." });
@@ -223,7 +226,7 @@ function buildDeepAnalysisMailto(opts: {
   ];
   const subject = encodeURIComponent(`Deeper analysis: ${opts.title} (${opts.parcelId})`);
   const body = encodeURIComponent(lines.join("\n"));
-  return `mailto:stephen@nantuckethouses.com?subject=${subject}&body=${body}`;
+  return `mailto:stephen@maury.net?subject=${subject}&body=${body}`;
 }
 
 export function PropertyIntelligencePanel({
@@ -323,10 +326,9 @@ export function PropertyIntelligencePanel({
       : selectedRental?.thumbUrl ?? parcelLinkListingMatch?.thumbUrl ?? null;
   const title =
     selectedLink?.address ??
-    selectedRental?.streetAddress ??
-    selectedRental?.headline ??
-    selectedParcel?.location ??
-    "Property";
+    (selectedParcel?.location && selectedRental != null
+      ? selectedParcel.location
+      : selectedRental?.streetAddress ?? selectedRental?.headline ?? selectedParcel?.location ?? "Property");
   const subPrice =
     selectedLink != null
       ? `${selectedLink.pool === "sold" ? selectedLink.closePrice || selectedLink.listPrice : selectedLink.listPrice} • ${selectedLink.pool === "sold" ? "Sold" : "Active"} • LINK MLS`
@@ -556,16 +558,16 @@ export function PropertyIntelligencePanel({
               </a>
             </Button>
           ) : null}
-          <Button asChild className="w-full bg-[var(--atlantic-navy)] text-sm text-white">
-            <a
-              href={`mailto:stephen@nantuckethouses.com?subject=${encodeURIComponent(`Property: ${title} — valuation / tour`)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              title="Custom valuation or property tour — opens your email app"
-            >
-              Message Stephen
-            </a>
-          </Button>
+          <a
+            href={`mailto:stephen@maury.net?subject=${encodeURIComponent(`Property: ${title} — valuation / tour`)}`}
+            className={cn(
+              buttonVariants({ size: "default" }),
+              "w-full bg-[var(--atlantic-navy)] text-sm text-white hover:bg-[var(--atlantic-navy)]/90",
+            )}
+            title="Custom valuation or property tour — opens your email app"
+          >
+            Message Stephen
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/zoning/MapLegend.tsx
+++ b/src/components/zoning/MapLegend.tsx
@@ -63,7 +63,7 @@ export function MapLegend({ showRentalsLegend = false, showLinkPinsLegend = fals
         <PinLegendRows
           showRentalsLegend={showRentalsLegend}
           showLinkPinsLegend={showLinkPinsLegend}
-          soldLabel="LINK — sold (matched to lot)"
+          soldLabel="Sold Listings (matched to lot)"
         />
       </div>
 
@@ -77,7 +77,7 @@ export function MapLegend({ showRentalsLegend = false, showLinkPinsLegend = fals
             <PinLegendRows
               showRentalsLegend={showRentalsLegend}
               showLinkPinsLegend={showLinkPinsLegend}
-              soldLabel="LINK — sold"
+              soldLabel="Sold Listings"
             />
           </div>
         ) : null}

--- a/src/components/zoning/ZoningLookupClient.tsx
+++ b/src/components/zoning/ZoningLookupClient.tsx
@@ -61,6 +61,9 @@ import { PropertyIntelligencePanel } from "@/components/map/PropertyIntelligence
 import type { OmniboxActiveListing, OmniboxRentalHit, OmniboxSoldComp } from "@/lib/map-omnibox-types";
 import { MAP_NEIGHBORHOOD_BOUNDS } from "@/lib/map-neighborhood-bounds";
 import { centroidFromGeometry } from "@/lib/geo-centroid";
+import { formatLinkMlsDateDisplay } from "@/lib/link-listing-date-format";
+import { findParcelFeatureByListingAddress, findParcelFeatureForLinkPin } from "@/lib/link-pin-parcel-resolve";
+import { findParcelFeatureForNrRental } from "@/lib/rental-parcel-resolve";
 import { bboxForReDistrictAbbrv } from "@/lib/re-districts-map";
 type RecentSoldParcelsFeed = {
   parcelIds: string[];
@@ -548,12 +551,24 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
   const slugByParcelIdForRentals = useMemo(() => nrRentalFeed.slugByParcelId, []);
 
   const vacationRentalSlugForSelection = useMemo(() => {
-    const pid = selectedParcel?.parcel_id;
-    if (!pid) return null;
-    return slugByParcelIdForRentals[String(pid).trim()] ?? null;
-  }, [selectedParcel?.parcel_id, slugByParcelIdForRentals]);
+    if (!selectedParcel?.parcel_id) return null;
+    const pid = String(selectedParcel.parcel_id).trim();
+    const tmKey = `${selectedParcel.tax_map ?? ""} ${selectedParcel.parcel ?? ""}`.trim();
+    return slugByParcelIdForRentals[pid] ?? slugByParcelIdForRentals[tmKey] ?? null;
+  }, [selectedParcel, slugByParcelIdForRentals]);
 
   rentalResultsRef.current = rentalResults;
+
+  /** When a lot has an NR slug on file and that listing is in the current viewport feed, attach it for rental pulse / hero. */
+  useEffect(() => {
+    if (!isPropertyMap || !selectedParcel?.parcel_id || selectedRental) return;
+    const pid = String(selectedParcel.parcel_id).trim();
+    const tmKey = `${selectedParcel.tax_map ?? ""} ${selectedParcel.parcel ?? ""}`.trim();
+    const slug = (slugByParcelIdForRentals[pid] || slugByParcelIdForRentals[tmKey])?.trim().toLowerCase();
+    if (!slug) return;
+    const hit = rentalResults.find((r) => (r.slug || "").trim().toLowerCase() === slug);
+    if (hit) setSelectedRental(hit);
+  }, [isPropertyMap, selectedParcel, selectedRental, slugByParcelIdForRentals, rentalResults]);
 
   const filteredRentals = useMemo(
     () => applyRentalFilters(rentalResults, rentalFilters),
@@ -597,50 +612,68 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
 
   const handleParcelSelectFromMap = useCallback((feature: ParcelFeature) => {
     setSelectedLink(null);
+    setSelectedRental(null);
     setSelectedParcel(feature.properties ?? null);
     setSearchStatus(null);
     setMobileDrawerTab("parcel");
     if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
   }, []);
 
-  const handleRentalPinSelect = useCallback((feature: RentalPinFeature) => {
-    const p = feature.properties;
-    const coords = (feature.geometry as Point).coordinates;
-    const id = Number(p.nrPropertyId);
-    const full = rentalResultsRef.current.find((r) => r.nrPropertyId === id);
-    setSelectedLink(null);
-    setSelectedRental(
-      full ?? {
-        nrPropertyId: id,
-        slug: p.slug,
-        streetAddress: p.streetAddress,
-        headline: p.headline,
-        latitude: coords[1],
-        longitude: coords[0],
-        thumbUrl: p.thumbUrl,
-        weeklyRentEstimate: null,
-        totalBedrooms: null,
-        totalBathrooms: null,
-        totalCapacity: null,
-        hasPool: false,
-        walkToBeach: false,
-        averageNightlyRate: null,
-        petFriendlyHint: false,
-        waterfrontHint: false,
-        renovatedHint: false,
-        townWalkHint: false,
-      },
-    );
-    setMobileDrawerTab("rental");
-    if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
-  }, []);
+  const handleRentalPinSelect = useCallback(
+    (feature: RentalPinFeature) => {
+      const p = feature.properties;
+      const coords = (feature.geometry as Point).coordinates;
+      const id = Number(p.nrPropertyId);
+      const full = rentalResultsRef.current.find((r) => r.nrPropertyId === id);
+      const rentalRow: NrMapRentalResult =
+        full ?? {
+          nrPropertyId: id,
+          slug: p.slug,
+          streetAddress: p.streetAddress,
+          headline: p.headline,
+          latitude: coords[1],
+          longitude: coords[0],
+          thumbUrl: p.thumbUrl,
+          weeklyRentEstimate: null,
+          totalBedrooms: null,
+          totalBathrooms: null,
+          totalCapacity: null,
+          hasPool: false,
+          walkToBeach: false,
+          averageNightlyRate: null,
+          petFriendlyHint: false,
+          waterfrontHint: false,
+          renovatedHint: false,
+          townWalkHint: false,
+        };
+      setSelectedLink(null);
+      setSelectedRental(rentalRow);
+      if (isPropertyMap) {
+        const parcelHit = findParcelFeatureForNrRental(rentalRow, slugByParcelIdForRentals, geojson?.features ?? []);
+        setSelectedParcel(parcelHit?.properties ?? null);
+      }
+      setMobileDrawerTab("parcel");
+      if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
+    },
+    [isPropertyMap, slugByParcelIdForRentals, geojson?.features],
+  );
 
-  const handleLinkListingPinSelect = useCallback((feature: LinkListingPinFeature) => {
-    setSelectedParcel(null);
-    setSelectedRental(null);
-    setSelectedLink(feature.properties);
-    if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
-  }, []);
+  const handleLinkListingPinSelect = useCallback(
+    (feature: LinkListingPinFeature) => {
+      const props = feature.properties;
+      setSelectedRental(null);
+      setSelectedLink(props);
+      if (isPropertyMap) {
+        const parcelHit = findParcelFeatureForLinkPin(props, geojson?.features ?? []);
+        setSelectedParcel(parcelHit?.properties ?? null);
+      } else {
+        setSelectedParcel(null);
+      }
+      setMobileDrawerTab("parcel");
+      if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
+    },
+    [isPropertyMap, geojson?.features],
+  );
 
   const handleViewportBoundsChange = useCallback((b: { west: number; south: number; east: number; north: number }) => {
     setMapBounds(b);
@@ -930,50 +963,65 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
     [features],
   );
 
-  const handleOmniboxRentalHit = useCallback((hit: OmniboxRentalHit) => {
-    setSelectedParcel(null);
-    setSelectedLink(null);
-    const full = rentalResultsRef.current.find((r) => r.nrPropertyId === hit.nrPropertyId);
-    const slug = (hit.slug?.trim() || full?.slug || "").trim();
-    setSelectedRental(
-      full ?? {
-        nrPropertyId: hit.nrPropertyId,
-        slug,
-        streetAddress: hit.address,
-        headline: hit.headline,
-        latitude: hit.lat,
-        longitude: hit.lng,
-        thumbUrl: null,
-        weeklyRentEstimate: null,
-        totalBedrooms: null,
-        totalBathrooms: null,
-        totalCapacity: null,
-        hasPool: false,
-        walkToBeach: false,
-        averageNightlyRate: null,
-        petFriendlyHint: false,
-        waterfrontHint: false,
-        renovatedHint: false,
-        townWalkHint: false,
-      },
-    );
-    setMapFlyTo({ id: bumpFlyId(), lng: hit.lng, lat: hit.lat, zoom: 15 });
-    setMobileDrawerTab("rental");
-    if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
-  }, []);
+  const handleOmniboxRentalHit = useCallback(
+    (hit: OmniboxRentalHit) => {
+      setSelectedLink(null);
+      const full = rentalResultsRef.current.find((r) => r.nrPropertyId === hit.nrPropertyId);
+      const slug = (hit.slug?.trim() || full?.slug || "").trim();
+      const rentalRow: NrMapRentalResult =
+        full ?? {
+          nrPropertyId: hit.nrPropertyId,
+          slug,
+          streetAddress: hit.address,
+          headline: hit.headline,
+          latitude: hit.lat,
+          longitude: hit.lng,
+          thumbUrl: null,
+          weeklyRentEstimate: null,
+          totalBedrooms: null,
+          totalBathrooms: null,
+          totalCapacity: null,
+          hasPool: false,
+          walkToBeach: false,
+          averageNightlyRate: null,
+          petFriendlyHint: false,
+          waterfrontHint: false,
+          renovatedHint: false,
+          townWalkHint: false,
+        };
+      setSelectedRental(rentalRow);
+      if (isPropertyMap) {
+        const parcelHit = findParcelFeatureForNrRental(rentalRow, slugByParcelIdForRentals, geojson?.features ?? []);
+        setSelectedParcel(parcelHit?.properties ?? null);
+      } else {
+        setSelectedParcel(null);
+      }
+      setMapFlyTo({ id: bumpFlyId(), lng: hit.lng, lat: hit.lat, zoom: 15 });
+      setMobileDrawerTab("parcel");
+      if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
+    },
+    [isPropertyMap, slugByParcelIdForRentals, geojson?.features],
+  );
 
   const handleOmniboxLinkHit = useCallback(
     (hit: OmniboxActiveListing | OmniboxSoldComp, pool: "active" | "sold") => {
-      setSelectedParcel(null);
       setSelectedRental(null);
       const onMap = findLinkPropsOnMap(hit.id, pool);
-      setSelectedLink(onMap ?? linkPinFromOmniboxHit(hit, pool));
+      const props = onMap ?? linkPinFromOmniboxHit(hit, pool);
+      setSelectedLink(props);
+      if (isPropertyMap) {
+        const parcelFeat = findParcelFeatureByListingAddress(hit.address, geojson?.features ?? []);
+        setSelectedParcel(parcelFeat?.properties ?? null);
+      } else {
+        setSelectedParcel(null);
+      }
       if (hit.lat != null && hit.lng != null) {
         setMapFlyTo({ id: bumpFlyId(), lng: hit.lng, lat: hit.lat, zoom: 15 });
       }
+      setMobileDrawerTab("parcel");
       if (isNarrowForParcelDrawer()) setMobilePanelOpen(true);
     },
-    [findLinkPropsOnMap],
+    [findLinkPropsOnMap, isPropertyMap, geojson?.features],
   );
 
   const handleViewComparableRentals = useCallback(() => {
@@ -1070,9 +1118,6 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
     return rows;
   }, [selectedParcel?.zoning]);
 
-  const selectedRentalPinKey = selectedRental ? String(selectedRental.nrPropertyId) : null;
-  const selectedLinkPinKey = selectedLink?.linkId ?? null;
-
   const showRentalPinsOnMap = isPropertyMap && (mapMode === "rent" || mapMode === "all");
   const showLinkPinsOnMap = isPropertyMap && (mapMode === "sale" || mapMode === "sold" || mapMode === "all");
 
@@ -1140,17 +1185,17 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
 
   const mapAddressPillLabel =
     selectedParcel?.location ??
+    selectedLink?.address ??
     selectedRental?.streetAddress ??
     selectedRental?.headline ??
-    selectedLink?.address ??
     "";
 
   const mapPillZoneBadge = useMemo(() => {
     if (districtMatch?.code) return districtMatch.code.toUpperCase().slice(0, 8);
     const z = selectedParcel?.zoning?.trim();
     if (z) return z.toUpperCase().slice(0, 8);
-    if (selectedRental) return "RENT";
     if (selectedLink) return (selectedLink.pool === "sold" ? "SOLD" : "LINK").slice(0, 8);
+    if (selectedRental) return "RENT";
     return "—";
   }, [districtMatch?.code, selectedParcel?.zoning, selectedRental, selectedLink]);
 
@@ -1418,13 +1463,13 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                     onParcelSelect={handleParcelSelectFromMap}
                     showRentalPins={isPropertyMap}
                     rentalGeoJson={isPropertyMap ? rentalGeoJson : null}
-                    selectedRentalFeatureId={isPropertyMap ? selectedRentalPinKey : null}
+                    selectedRentalFeatureId={null}
                     onRentalPinSelect={isPropertyMap ? handleRentalPinSelect : undefined}
                     onViewportBoundsChange={isPropertyMap ? handleViewportBoundsChange : undefined}
                     showLinkPins={isPropertyMap}
                     linkActiveGeoJson={isPropertyMap ? filteredLinkActiveFc : null}
                     linkSoldGeoJson={isPropertyMap ? filteredLinkSoldFc : null}
-                    selectedLinkListingId={isPropertyMap ? selectedLinkPinKey : null}
+                    selectedLinkListingId={null}
                     onLinkListingPinSelect={isPropertyMap ? handleLinkListingPinSelect : undefined}
                     flyTo={isPropertyMap ? mapFlyTo : null}
                     reDistrictsGeoJson={isPropertyMap ? reDistrictsGeoJson : null}
@@ -1704,26 +1749,6 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   </p>
                 ) : null}
                 <div className="flex max-h-[min(28rem,55vh)] shrink-0 flex-col gap-2 overflow-y-auto">
-                {mapMode === "rent" || mapMode === "all" ? (
-                  <div className="shrink-0 rounded-lg border border-[var(--cedar-shingle)]/20 bg-white p-3 shadow-sm">
-                    <div className="flex items-center justify-between gap-2">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-[var(--atlantic-navy)]">
-                          {filteredRentals.length} Active Vacation Rentals in view
-                        </p>
-                        {rentFilterActiveCount > 0 && rentalResults.length !== filteredRentals.length ? (
-                          <p className="text-[10px] font-normal text-[var(--nantucket-gray)]">{rentalResults.length} before filters</p>
-                        ) : null}
-                      </div>
-                      {rentalsLoading ? <span className="text-[10px] text-[var(--nantucket-gray)]">Loading…</span> : null}
-                    </div>
-                    {!rentalsLoading && rentalResults.length === 0 ? (
-                      <p className="mt-2 text-xs text-[var(--nantucket-gray)]">None in view.</p>
-                    ) : !rentalsLoading && filteredRentals.length === 0 ? (
-                      <p className="mt-2 text-xs text-[var(--nantucket-gray)]">No rentals match your filters in this view.</p>
-                    ) : null}
-                  </div>
-                ) : null}
                 {mapMode === "sale" || mapMode === "all" ? (
                   <div className="max-h-44 shrink-0 overflow-y-auto rounded-lg border border-[var(--cedar-shingle)]/20 bg-white p-3 shadow-sm">
                     <div className="mb-2 flex items-center justify-between gap-2">
@@ -1743,9 +1768,10 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                               <button
                                 type="button"
                                 onClick={() => {
-                                  setSelectedParcel(null);
                                   setSelectedRental(null);
                                   setSelectedLink(p);
+                                  const feat = findParcelFeatureForLinkPin(p, features);
+                                  setSelectedParcel(feat?.properties ?? null);
                                 }}
                                 className={cn(
                                   "flex w-full flex-col items-start rounded-md border px-2 py-2 text-left text-sm transition-colors",
@@ -1767,7 +1793,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                 {mapMode === "sold" || mapMode === "all" ? (
                   <div className="max-h-44 shrink-0 overflow-y-auto rounded-lg border border-[var(--cedar-shingle)]/20 bg-white p-3 shadow-sm">
                     <div className="mb-2 flex items-center justify-between gap-2">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--atlantic-navy)]">LINK — Sold</p>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--atlantic-navy)]">Sold Listings</p>
                       {linkListingsLoading ? <span className="text-[10px] text-[var(--nantucket-gray)]">Loading…</span> : null}
                     </div>
                     {linkSoldFc.features.length === 0 && !linkListingsLoading ? (
@@ -1783,9 +1809,10 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                               <button
                                 type="button"
                                 onClick={() => {
-                                  setSelectedParcel(null);
                                   setSelectedRental(null);
                                   setSelectedLink(p);
+                                  const feat = findParcelFeatureForLinkPin(p, features);
+                                  setSelectedParcel(feat?.properties ?? null);
                                 }}
                                 className={cn(
                                   "flex w-full flex-col items-start rounded-md border px-2 py-2 text-left text-sm transition-colors",
@@ -1797,7 +1824,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                                 <span className="font-medium text-[var(--atlantic-navy)]">{p.address}</span>
                                 <span className="text-xs text-[var(--nantucket-gray)]">
                                   {p.closePrice ? `Sold ${p.closePrice}` : p.listPrice}
-                                  {p.closeDate ? ` · ${p.closeDate}` : ""}
+                                  {p.closeDate ? ` · ${formatLinkMlsDateDisplay(p.closeDate)}` : ""}
                                 </span>
                               </button>
                             </li>
@@ -1889,47 +1916,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   onWatchChange={() => setWatchTick((t) => t + 1)}
                   onViewComparableRentals={handleViewComparableRentals}
                 />
-                {selectedParcel && selectedRental ? (
-                  <>
-                    <div className="inline-flex rounded-full border border-[var(--cedar-shingle)]/25 bg-white p-1">
-                      <button
-                        type="button"
-                        onClick={() => setMobileDrawerTab("rental")}
-                        className={cn(
-                          "rounded-full px-3 py-1 text-xs font-medium",
-                          mobileDrawerTab === "rental"
-                            ? "bg-[var(--privet-green)] text-white"
-                            : "text-[var(--atlantic-navy)]",
-                        )}
-                      >
-                        Rental details
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setMobileDrawerTab("parcel")}
-                        className={cn(
-                          "rounded-full px-3 py-1 text-xs font-medium",
-                          mobileDrawerTab === "parcel"
-                            ? "bg-[var(--atlantic-navy)] text-white"
-                            : "text-[var(--atlantic-navy)]",
-                        )}
-                      >
-                        Parcel &amp; zoning
-                      </button>
-                    </div>
-                    {mobileDrawerTab === "parcel" ? (
-                      <ParcelDetailPanel
-                        {...parcelMapCtas}
-                        selectedParcel={selectedParcel}
-                        zoningLabel={zoningLabel}
-                        districtMatch={districtMatch}
-                        zoningUseRows={zoningUseRows}
-                        linkListingId={linkListingIdForSelection}
-                        vacationRentalSlug={vacationRentalSlugForSelection}
-                      />
-                    ) : null}
-                  </>
-                ) : selectedParcel ? (
+                {selectedParcel ? (
                   <ParcelDetailPanel
                     {...parcelMapCtas}
                     selectedParcel={selectedParcel}
@@ -1939,6 +1926,11 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                     linkListingId={linkListingIdForSelection}
                     vacationRentalSlug={vacationRentalSlugForSelection}
                   />
+                ) : selectedRental ? (
+                  <p className="rounded-md border border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)]/40 px-3 py-2 text-center text-xs text-[var(--nantucket-gray)]">
+                    This vacation rental pin did not match a loaded tax parcel. Zoom to Nantucket or tap a lot on the map
+                    for full parcel and zoning detail.
+                  </p>
                 ) : null}
               </div>
             ) : selectedRental && selectedParcel ? (
@@ -2098,7 +2090,9 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                     <>
                       {selectedLink.closePrice ? <>Sold {selectedLink.closePrice}</> : null}
                       {selectedLink.closePrice && selectedLink.closeDate ? " · " : null}
-                      {selectedLink.closeDate ? <span>Closed {selectedLink.closeDate}</span> : null}
+                      {selectedLink.closeDate ? (
+                        <span>Closed {formatLinkMlsDateDisplay(selectedLink.closeDate)}</span>
+                      ) : null}
                       {!selectedLink.closePrice && selectedLink.listPrice ? (
                         <span>Listed {selectedLink.listPrice}</span>
                       ) : null}
@@ -2121,7 +2115,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   </a>
                 </Button>
                 <p className="text-center text-xs text-[var(--nantucket-gray)]">
-                  Pin is placed at the matched tax parcel centroid; verify on the official listing.
+                  Pin is placed inside the matched tax parcel (interior label point); verify on the official listing.
                 </p>
               </div>
             ) : (

--- a/src/lib/geo-centroid.ts
+++ b/src/lib/geo-centroid.ts
@@ -1,19 +1,5 @@
 import type { Geometry } from "geojson";
-
-function ringCentroid(ring: number[][]): { lng: number; lat: number } | null {
-  if (!ring?.length) return null;
-  let sx = 0;
-  let sy = 0;
-  let n = 0;
-  for (const p of ring) {
-    if (p.length >= 2 && typeof p[0] === "number" && typeof p[1] === "number") {
-      sx += p[0];
-      sy += p[1];
-      n++;
-    }
-  }
-  return n > 0 ? { lng: sx / n, lat: sy / n } : null;
-}
+import polylabel from "polylabel";
 
 function ringAreaAbs(ring: number[][]): number {
   if (ring.length < 3) return 0;
@@ -26,26 +12,41 @@ function ringAreaAbs(ring: number[][]): number {
   return Math.abs(sum / 2);
 }
 
-/** Simple centroid for parcel polygons (Mapbox GeoJSON). */
+/**
+ * Best interior point for map pins / labels on tax parcels (lng/lat).
+ *
+ * Previously we averaged **boundary vertices**, which pulls pins toward dense corners
+ * and can sit visibly off the lot interior vs the filled parcel polygon. Polylabel
+ * (pole of inaccessibility) maximizes clearance from edges while staying **inside**
+ * the polygon (including holes), so pins align with the parcel fill users see.
+ */
 export function centroidFromGeometry(geom: Geometry): { lng: number; lat: number } | null {
+  /** ~1 m at Nantucket lat — tight enough for lots without excessive work. */
+  const precision = 1e-5;
+
   if (geom.type === "Polygon") {
-    const ring = geom.coordinates[0];
-    return ring ? ringCentroid(ring) : null;
+    const rings = geom.coordinates as number[][][];
+    if (!rings?.length || !rings[0]?.length) return null;
+    const pt = polylabel(rings, precision);
+    return { lng: pt[0]!, lat: pt[1]! };
   }
+
   if (geom.type === "MultiPolygon") {
-    let best: { lng: number; lat: number } | null = null;
+    let bestCoords: number[][][] | null = null;
     let bestA = 0;
     for (const poly of geom.coordinates) {
       const ring = poly[0];
-      if (!ring) continue;
-      const c = ringCentroid(ring);
+      if (!ring?.length) continue;
       const a = ringAreaAbs(ring);
-      if (c && a > bestA) {
+      if (a > bestA) {
         bestA = a;
-        best = c;
+        bestCoords = poly as number[][][];
       }
     }
-    return best;
+    if (!bestCoords?.length) return null;
+    const pt = polylabel(bestCoords, precision);
+    return { lng: pt[0]!, lat: pt[1]! };
   }
+
   return null;
 }

--- a/src/lib/link-listing-date-format.ts
+++ b/src/lib/link-listing-date-format.ts
@@ -1,0 +1,30 @@
+const MONTHS_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+
+/**
+ * Display MLS-style dates as `MMM DD, YYYY` (e.g. `Jan 05, 2024`).
+ * Handles common ISO `YYYY-MM-DD` without UTC day-shift.
+ */
+export function formatLinkMlsDateDisplay(raw: string | null | undefined): string {
+  const s = raw != null ? String(raw).trim() : "";
+  if (!s) return "";
+
+  const iso = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  if (iso) {
+    const y = Number(iso[1]);
+    const m = Number(iso[2]) - 1;
+    const day = Number(iso[3]);
+    if (m >= 0 && m < 12 && day >= 1 && day <= 31 && !Number.isNaN(y)) {
+      const mon = MONTHS_SHORT[m];
+      return `${mon} ${String(day).padStart(2, "0")}, ${y}`;
+    }
+  }
+
+  const ms = Date.parse(s);
+  if (!Number.isNaN(ms)) {
+    const d = new Date(ms);
+    const mon = MONTHS_SHORT[d.getMonth()];
+    return `${mon} ${String(d.getDate()).padStart(2, "0")}, ${d.getFullYear()}`;
+  }
+
+  return s;
+}

--- a/src/lib/link-listings-parcel-match.ts
+++ b/src/lib/link-listings-parcel-match.ts
@@ -37,6 +37,8 @@ export type LinkListingRow = {
 
 export type LinkListingMapPoint = {
   linkId: number;
+  /** Assessor parcel_id when the listing street matched a parcel centroid in the index. */
+  parcel_id: string;
   longitude: number;
   latitude: number;
   address: string;
@@ -181,6 +183,7 @@ export function matchLinkListingToPoint(
   const area = String(row.MLSAreaMajor ?? "").trim();
   return {
     linkId: id,
+    parcel_id: String(hit.parcel_id).trim(),
     longitude: hit.lng,
     latitude: hit.lat,
     address: stem,

--- a/src/lib/link-pin-parcel-resolve.ts
+++ b/src/lib/link-pin-parcel-resolve.ts
@@ -1,0 +1,31 @@
+import type { Feature, Geometry } from "geojson";
+import type { LinkListingPinProperties } from "@/lib/link-listings-parcel-match";
+import { buildParcelStreetCentroidIndex, type ParcelProps } from "@/lib/link-listings-parcel-match";
+import { listingAddressStem, streetMatchKey } from "@/lib/address-street-key";
+
+/**
+ * Resolve a LINK listing address (MLS / pin `address`) to a tax parcel feature
+ * using the same street-key → centroid index as `/api/map/link-listings`.
+ */
+export function findParcelFeatureByListingAddress<G extends { parcel_id?: string | null }>(
+  address: string,
+  features: Feature<Geometry, G>[],
+): Feature<Geometry, G> | null {
+  if (!features.length) return null;
+  const index = buildParcelStreetCentroidIndex(features as Feature<Geometry, ParcelProps>[]);
+  const stem = listingAddressStem(address);
+  if (!stem) return null;
+  const key = streetMatchKey(stem);
+  if (!key) return null;
+  const hit = index.get(key);
+  if (!hit) return null;
+  const pid = hit.parcel_id.trim();
+  return features.find((f) => String(f.properties?.parcel_id ?? "").trim() === pid) ?? null;
+}
+
+export function findParcelFeatureForLinkPin<G extends { parcel_id?: string | null }>(
+  props: LinkListingPinProperties,
+  features: Feature<Geometry, G>[],
+): Feature<Geometry, G> | null {
+  return findParcelFeatureByListingAddress(props.address, features);
+}

--- a/src/lib/map-omnibox-types.ts
+++ b/src/lib/map-omnibox-types.ts
@@ -1,5 +1,15 @@
 export type ExpansionVerdictOmnibox = "HIGH" | "MODERATE" | "MAXED";
 
+/** When a LINK or NR rental row maps to this parcel, omnibox shows one parcel row (no duplicate listing rows). */
+export type OmniboxParcelListingMatch = {
+  kind: "link_active" | "link_sold" | "rental";
+  linkId?: string;
+  nrPropertyId?: number;
+  rentalSlug?: string | null;
+  priceLabel: string;
+  statusLabel: string;
+};
+
 export type OmniboxActiveListing = {
   id: string;
   address: string;
@@ -7,6 +17,8 @@ export type OmniboxActiveListing = {
   priceLabel: string;
   lat: number | null;
   lng: number | null;
+  /** Assessor parcel_id when street matched parcel centroid index (omnibox may merge into parcel row). */
+  parcelId?: string | null;
   source: "LINK";
   status: "for_sale";
 };
@@ -19,6 +31,7 @@ export type OmniboxSoldComp = {
   closeDate: string | null;
   lat: number | null;
   lng: number | null;
+  parcelId?: string | null;
   source: "LINK";
   status: "sold";
 };
@@ -33,6 +46,8 @@ export type OmniboxParcelHit = {
   /** Normalized zoning code when available from parcel GIS. */
   zone?: string | null;
   expansionVerdict?: ExpansionVerdictOmnibox | null;
+  /** Highest-priority listing/rental merged into this parcel row (active LINK beats sold beats rental). */
+  matchedListing?: OmniboxParcelListingMatch | null;
 };
 
 export type OmniboxNeighborhoodHit = {
@@ -52,6 +67,7 @@ export type OmniboxRentalHit = {
   priceLabel: string | null;
   lat: number;
   lng: number;
+  parcelId?: string | null;
 };
 
 export type OmniboxNlSuggestion = {
@@ -87,6 +103,7 @@ export type OmniboxCategories = {
     expansionVerdict: ExpansionVerdictOmnibox | null;
     lat: number;
     lng: number;
+    matchedListing: OmniboxParcelListingMatch | null;
   }>;
   neighborhoods: Array<{
     id: string;

--- a/src/lib/rental-parcel-resolve.ts
+++ b/src/lib/rental-parcel-resolve.ts
@@ -1,0 +1,51 @@
+import type { Feature, Geometry } from "geojson";
+import { listingAddressStem, looksLikeStreetAddress, streetMatchKey } from "@/lib/address-street-key";
+
+/** Minimal parcel fields needed to match an NR rental pin to a tax lot. */
+export type ParcelPropsForRentalMatch = {
+  parcel_id?: string | null;
+  tax_map?: string | null;
+  parcel?: string | null;
+  location?: string | null;
+};
+
+export type ParcelFeatureForRentalMatch = Feature<Geometry, ParcelPropsForRentalMatch>;
+
+function taxParcelLookupKey(p: ParcelPropsForRentalMatch): string {
+  return `${p.tax_map ?? ""} ${p.parcel ?? ""}`.trim();
+}
+
+/**
+ * Find the tax parcel feature for a vacation rental (slug from NR ↔ parcel feed,
+ * else normalized street vs assessor `location`).
+ */
+export function findParcelFeatureForNrRental(
+  rental: { slug?: string | null; streetAddress?: string | null },
+  slugByParcelId: Record<string, string>,
+  features: ParcelFeatureForRentalMatch[],
+): ParcelFeatureForRentalMatch | null {
+  const slug = String(rental.slug ?? "").trim().toLowerCase();
+  if (slug) {
+    for (const [feedKey, feedSlug] of Object.entries(slugByParcelId)) {
+      if (String(feedSlug).trim().toLowerCase() !== slug) continue;
+      const k = String(feedKey).trim();
+      const byPid = features.find((f) => String(f.properties?.parcel_id ?? "").trim() === k);
+      if (byPid) return byPid;
+      const byTm = features.find((f) => taxParcelLookupKey(f.properties ?? {}).toLowerCase() === k.toLowerCase());
+      if (byTm) return byTm;
+    }
+  }
+
+  const stem = listingAddressStem(rental.streetAddress ?? undefined);
+  if (!stem || !looksLikeStreetAddress(stem)) return null;
+  const key = streetMatchKey(stem);
+  if (!key) return null;
+
+  for (const f of features) {
+    const loc = String(f.properties?.location ?? "").trim();
+    if (!loc || !looksLikeStreetAddress(loc)) continue;
+    const locStem = listingAddressStem(loc);
+    if (streetMatchKey(locStem) === key || streetMatchKey(loc) === key) return f;
+  }
+  return null;
+}

--- a/src/lib/schedule-call-url.ts
+++ b/src/lib/schedule-call-url.ts
@@ -1,0 +1,2 @@
+/** Google Calendar scheduling — used for “Schedule a Call” / book time with Stephen. */
+export const SCHEDULE_CALL_URL = "https://calendar.app.google/e6pvoyZwp3Fe64gv5";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,8 @@ export type WhaleWatchSale = {
   closeDate: string;
   neighborhood: string;
   listPrice?: number;
+  /** Nantucket LINK MLS listing id when provided by the API (sold listing detail page). */
+  linkListingId?: string;
 };
 
 export type WhaleWatchData = {

--- a/src/types/polylabel.d.ts
+++ b/src/types/polylabel.d.ts
@@ -1,0 +1,8 @@
+declare module "polylabel" {
+  /** GeoJSON-style polygon: outer ring + holes; coordinates in map CRS (lng, lat). */
+  export default function polylabel(
+    polygon: number[][][],
+    precision?: number,
+    debug?: boolean,
+  ): [number, number] & { distance?: number };
+}


### PR DESCRIPTION
## Summary
- **Omnibox / property map / zoning lookup** — prior work on parcel vs listing dedupe, popover theming, scheduling URL, intel panel, map legend, and new helpers (`link-listing-date-format`, `link-pin-parcel-resolve`, `rental-parcel-resolve`).
- **Navigation** — Resources mega menu uses a fixed, viewport-clamped shell so it no longer runs off the right edge.
- **Whale Watch** — Surfaces `linkListingId` from the CNC API and links sale addresses to public LINK listing pages when available.
- **Contact** — Gut Check CTAs use `mailto:stephen@maury.net`; static mailto / JSON-LD / footer / map footer / opportunities recipient aligned to `stephen@maury.net`.
- **Parcel pins** — Replaces vertex-average “centroid” with **polylabel** so LINK pins sit inside the tax lot polygon.

## Test plan
- [ ] Desktop: hover Resources mega — panel fits viewport; hover bridge still works.
- [ ] Home & Whale Watch pages — table addresses link to LINK when `link_id` present.
- [ ] Property map — pins visually inside parcel fills for a few irregular lots.
- [ ] Gut Check / footer / map footer mailto opens client with `stephen@maury.net`.