### PR TITLE
Property map: NR rentals cache + filters, overlay, and panel UX

### DIFF
--- a/src/app/api/cron/warm-map-rentals/route.ts
+++ b/src/app/api/cron/warm-map-rentals/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { warmMapRentalsInventory } from "@/lib/map-rentals-inventory-cache";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/cron/warm-map-rentals
+ * Warms Next.js unstable_cache for the full NR map inventory (see map-rentals-inventory-cache).
+ *
+ * Vercel Cron: set CRON_SECRET and add schedule in vercel.json. The platform sends
+ * Authorization: Bearer <CRON_SECRET> when that env var is set.
+ */
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  } else if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "CRON_SECRET is not configured" }, { status: 500 });
+  }
+
+  try {
+    const { count } = await warmMapRentalsInventory();
+    return NextResponse.json({ ok: true, activeRows: count });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Warm failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/map/rentals/route.ts
+++ b/src/app/api/map/rentals/route.ts
@@ -1,70 +1,13 @@
 import { NextResponse } from "next/server";
 import type { NrMapRentalResult } from "@/lib/nr-map-rentals";
+import { getMapRentalResultsForBbox } from "@/lib/map-rentals-inventory-cache";
 
-function getNrListingsApiBase(): string {
-  const raw = process.env.NR_LISTINGS_API_BASE ?? "https://api.nantucketrentals.com/api";
-  return raw.trim().replace(/\/$/, "");
-}
-
-type NrListingRow = {
-  nrPropertyId?: number;
-  slug?: string;
-  streetAddress?: string;
-  headline?: string;
-  latitude?: number;
-  longitude?: number;
-  status?: string;
-  NrPropertyPics?: { nrPropertyPicPath?: string }[];
-  NrRentalRates?: { propertyWeeklyRentInteger?: number; propertyWeeklyRent?: number }[];
-  averageNightlyRate?: number;
-  totalBedrooms?: number;
-  totalBathrooms?: number;
-  totalCapacity?: number;
-  hasPool?: boolean;
-  walkToBeach?: boolean;
-  highlights?: string | null;
-};
-
-function deriveWeeklyRent(row: NrListingRow): number | null {
-  const rates = row.NrRentalRates ?? [];
-  const ints = rates
-    .map((r) => r.propertyWeeklyRentInteger ?? r.propertyWeeklyRent)
-    .filter((n): n is number => typeof n === "number" && !Number.isNaN(n) && n > 0);
-  if (ints.length) return Math.round(Math.max(...ints));
-  const nightly = row.averageNightlyRate;
-  if (typeof nightly === "number" && !Number.isNaN(nightly) && nightly > 0) return Math.round(nightly * 7);
-  return null;
-}
-
-function textBlob(row: NrListingRow): string {
-  return [row.headline, row.streetAddress, row.slug, row.highlights].filter(Boolean).join(" ");
-}
-
-function petFriendlyHint(row: NrListingRow): boolean {
-  return /\b(pet|pets|dog|dogs|cat|cats)\b/i.test(textBlob(row));
-}
-
-function waterfrontHint(row: NrListingRow): boolean {
-  return /\b(waterfront|oceanfront|harbor|harbour|sound front|on the water|water view|beachfront)\b/i.test(textBlob(row));
-}
-
-function renovatedHint(row: NrListingRow): boolean {
-  return /\b(renovated|renovation|fully updated|gut renovated|like new|newly renovated|designer|restored)\b/i.test(textBlob(row));
-}
-
-function townWalkHint(row: NrListingRow): boolean {
-  return /\b(downtown|in town|in-town|town center|center of town|historic district|main street|steps to town|walk to town)\b/i.test(
-    textBlob(row),
-  );
-}
-
-function inBbox(lng: number, lat: number, west: number, south: number, east: number, north: number): boolean {
-  return lng >= west && lng <= east && lat >= south && lat <= north;
-}
+export const runtime = "nodejs";
 
 /**
  * GET /api/map/rentals?bbox=west,south,east,north
  * Proxies active Nantucket Rentals inventory for map pins (public listing API).
+ * Full catalog is fetched with pagination once per revalidate window (cached); bbox filter is in-memory.
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -80,65 +23,18 @@ export async function GET(request: Request) {
     }
     [west, south, east, north] = parts as [number, number, number, number];
   } else {
-    // Nantucket island-ish bounds when no viewport yet
     west = -70.2;
     south = 41.22;
     east = -69.95;
     north = 41.33;
   }
 
-  const base = getNrListingsApiBase();
-  const collected: NrListingRow[] = [];
-  let nextUrl: string | null = `${base}/property/nrproperty-listing/?page=1&page_size=500`;
-
-  try {
-    while (nextUrl) {
-      const res = await fetch(nextUrl, {
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      });
-      if (!res.ok) {
-        return NextResponse.json({ error: `Listings upstream ${res.status}`, results: [] as NrMapRentalResult[] }, { status: 502 });
-      }
-      const body = (await res.json()) as { results?: NrListingRow[]; next?: string | null };
-      for (const row of body.results ?? []) {
-        if ((row.status ?? "").toLowerCase() === "active") collected.push(row);
-      }
-      nextUrl = body.next ?? null;
-    }
-  } catch {
-    return NextResponse.json({ error: "Failed to fetch rentals", results: [] }, { status: 502 });
-  }
-
-  const results: NrMapRentalResult[] = [];
-  for (const row of collected) {
-    const id = row.nrPropertyId;
-    const slug = row.slug?.trim();
-    const lat = row.latitude;
-    const lng = row.longitude;
-    if (id == null || !slug || lat == null || lng == null || Number.isNaN(lat) || Number.isNaN(lng)) continue;
-    if (!inBbox(lng, lat, west, south, east, north)) continue;
-    const thumb = row.NrPropertyPics?.[0]?.nrPropertyPicPath ?? null;
-    results.push({
-      nrPropertyId: id,
-      slug,
-      streetAddress: String(row.streetAddress ?? "").trim() || slug,
-      headline: String(row.headline ?? row.streetAddress ?? slug).trim(),
-      latitude: lat,
-      longitude: lng,
-      thumbUrl: thumb,
-      weeklyRentEstimate: deriveWeeklyRent(row),
-      totalBedrooms: typeof row.totalBedrooms === "number" ? row.totalBedrooms : null,
-      totalBathrooms: typeof row.totalBathrooms === "number" ? row.totalBathrooms : null,
-      totalCapacity: typeof row.totalCapacity === "number" ? row.totalCapacity : null,
-      hasPool: Boolean(row.hasPool),
-      walkToBeach: Boolean(row.walkToBeach),
-      averageNightlyRate: typeof row.averageNightlyRate === "number" ? row.averageNightlyRate : null,
-      petFriendlyHint: petFriendlyHint(row),
-      waterfrontHint: waterfrontHint(row),
-      renovatedHint: renovatedHint(row),
-      townWalkHint: townWalkHint(row),
-    });
+  const { results, inventoryError } = await getMapRentalResultsForBbox(west, south, east, north);
+  if (inventoryError) {
+    return NextResponse.json(
+      { error: "Failed to fetch rentals", results: [] as NrMapRentalResult[] },
+      { status: 502 },
+    );
   }
 
   return NextResponse.json({ results });

--- a/src/app/disclaimer/page.tsx
+++ b/src/app/disclaimer/page.tsx
@@ -20,11 +20,6 @@ export default function DisclaimerPage() {
       <section className="py-12">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="bg-white rounded-lg border border-[var(--cedar-shingle)]/20 p-6 sm:p-8 space-y-6 text-sm text-[var(--atlantic-navy)]/85 leading-relaxed">
-            <p>
-              This disclaimer is boilerplate content intended as a placeholder and should be reviewed with legal
-              counsel before final publication.
-            </p>
-
             <div>
               <h2 className="text-base text-[var(--atlantic-navy)] font-semibold mb-2">Market Information</h2>
               <p>

--- a/src/components/map/MapResearchHubStickyFooter.tsx
+++ b/src/components/map/MapResearchHubStickyFooter.tsx
@@ -6,59 +6,77 @@ import { SCHEDULE_CALL_URL } from "@/lib/schedule-call-url";
 
 type Props = {
   className?: string;
+  /** When false, hides phone and email (e.g. mobile slide-up drawer). */
+  showContactLinks?: boolean;
+  /** When false, hides Privacy / Terms / Disclaimer (e.g. mobile slide-up drawer). */
+  showLegalNav?: boolean;
+  /** Defaults to calendar booking; set for vacation-rental pin context (e.g. listing or NR search). */
+  primaryCtaHref?: string;
+  /** Defaults to “Schedule a Call”. */
+  primaryCtaLabel?: string;
 };
 
 /** Sticky lead + compliance strip for the property map research hub (desktop sidebar + mobile drawer). */
-export function MapResearchHubStickyFooter({ className }: Props) {
+export function MapResearchHubStickyFooter({
+  className,
+  showContactLinks = true,
+  showLegalNav = true,
+  primaryCtaHref = SCHEDULE_CALL_URL,
+  primaryCtaLabel = "Schedule a Call",
+}: Props) {
   return (
     <div className={cn("shrink-0 space-y-2", className)}>
       <a
-        href={SCHEDULE_CALL_URL}
+        href={primaryCtaHref}
         target="_blank"
         rel="noopener noreferrer"
         className="flex w-full items-center justify-center rounded-md bg-[var(--privet-green)] px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[var(--brass-hover)]"
       >
-        Schedule a Call
+        {primaryCtaLabel}
       </a>
-      <p className="flex flex-wrap items-center justify-center gap-x-1 text-center text-[10px] leading-snug text-[var(--nantucket-gray)]/85">
-        <a
-          href="tel:+15084510191"
-          className="inline-flex min-h-10 max-w-full items-center rounded-md px-2 underline-offset-2 hover:underline"
-          aria-label="Call Stephen Maury at (508) 451-0191"
+      {showContactLinks ? (
+        <p className="flex flex-wrap items-center justify-center gap-x-1 text-center text-[10px] leading-snug text-[var(--nantucket-gray)]/85">
+          <a
+            href="tel:+15084510191"
+            className="inline-flex min-h-10 max-w-full items-center rounded-md px-2 underline-offset-2 hover:underline"
+            aria-label="Call Stephen Maury at (508) 451-0191"
+          >
+            (508) 451-0191
+          </a>
+          <span className="shrink-0 text-[var(--nantucket-gray)]/45" aria-hidden>
+            ·
+          </span>
+          <a
+            href="mailto:stephen@maury.net"
+            className="inline-flex min-h-10 max-w-full items-center rounded-md px-2 underline-offset-2 hover:underline"
+            aria-label="Email stephen@maury.net"
+          >
+            stephen@maury.net
+          </a>
+        </p>
+      ) : null}
+      {showLegalNav ? (
+        <nav
+          className="flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[10px] text-[var(--nantucket-gray)]/55"
+          aria-label="Legal and policies"
         >
-          (508) 451-0191
-        </a>
-        <span className="shrink-0 text-[var(--nantucket-gray)]/45" aria-hidden>
-          ·
-        </span>
-        <a
-          href="mailto:stephen@maury.net"
-          className="inline-flex min-h-10 max-w-full items-center rounded-md px-2 underline-offset-2 hover:underline"
-          aria-label="Email stephen@maury.net"
-        >
-          stephen@maury.net
-        </a>
-      </p>
-      <nav
-        className="flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[10px] text-[var(--nantucket-gray)]/55"
-        aria-label="Legal and policies"
-      >
-        <Link href="/privacy" className="hover:text-[var(--atlantic-navy)]/75 hover:underline">
-          Privacy
-        </Link>
-        <span className="text-[var(--nantucket-gray)]/35" aria-hidden>
-          ·
-        </span>
-        <Link href="/terms" className="hover:text-[var(--atlantic-navy)]/75 hover:underline">
-          Terms
-        </Link>
-        <span className="text-[var(--nantucket-gray)]/35" aria-hidden>
-          ·
-        </span>
-        <Link href="/disclaimer" className="hover:text-[var(--atlantic-navy)]/75 hover:underline">
-          Disclaimer
-        </Link>
-      </nav>
+          <Link href="/privacy" className="hover:text-[var(--atlantic-navy)]/75 hover:underline">
+            Privacy
+          </Link>
+          <span className="text-[var(--nantucket-gray)]/35" aria-hidden>
+            ·
+          </span>
+          <Link href="/terms" className="hover:text-[var(--atlantic-navy)]/75 hover:underline">
+            Terms
+          </Link>
+          <span className="text-[var(--nantucket-gray)]/35" aria-hidden>
+            ·
+          </span>
+          <Link href="/disclaimer" className="hover:text-[var(--atlantic-navy)]/75 hover:underline">
+            Disclaimer
+          </Link>
+        </nav>
+      ) : null}
     </div>
   );
 }

--- a/src/components/map/PropertyIntelligenceHero.tsx
+++ b/src/components/map/PropertyIntelligenceHero.tsx
@@ -136,14 +136,21 @@ export function PropertyIntelligenceHero({
   const satelliteUrl = useMemo(() => {
     if (!center || satFailed) return null;
     const w = 400;
-    const h = compactHero ? 220 : 250;
+    const h = compactHero ? 320 : 250;
     return mapboxSatelliteStaticUrl({ lng: center.lng, lat: center.lat, zoom: 18, width: w, height: h, retina: true });
   }, [center, compactHero, satFailed]);
 
   const zoneBadge = zoneHeadline(districtMatch, parcelZoning, zoningLabel);
 
   return (
-    <div className={cn("relative w-full overflow-hidden rounded-t-lg bg-slate-200", compactHero ? "aspect-[4/3]" : "aspect-video")}>
+    <div
+      className={cn(
+        "relative w-full overflow-hidden bg-slate-200",
+        compactHero
+          ? "min-h-[220px] h-[40vh] max-h-[min(360px,52dvh)] rounded-t-none"
+          : "aspect-video rounded-t-lg",
+      )}
+    >
       {heroUrl ? (
         heroListingHref ? (
           <a
@@ -198,7 +205,7 @@ export function PropertyIntelligenceHero({
         >
           {statusLabel}
         </span>
-        {parcelId ? (
+        {!compactHero && parcelId ? (
           <button
             type="button"
             onClick={onToggleWatch}

--- a/src/components/map/PropertyIntelligencePanel.tsx
+++ b/src/components/map/PropertyIntelligencePanel.tsx
@@ -11,7 +11,10 @@ import type { LinkListingPinProperties, ParcelMapLinkListingMatch } from "@/lib/
 import type { NrMapRentalResult } from "@/lib/nr-map-rentals";
 import { nantucketLinkListingUrl } from "@/lib/link-listing-url";
 import { formatLinkMlsDateDisplay } from "@/lib/link-listing-date-format";
-import { nantucketVacationRentalListingUrl } from "@/lib/nr-vacation-rental-url";
+import {
+  nantucketRentalsComparableSearchUrlFromListingBedrooms,
+  nantucketVacationRentalListingUrl,
+} from "@/lib/nr-vacation-rental-url";
 import {
   formatExpansionIdea,
   getExpansionIntelligence,
@@ -45,9 +48,37 @@ function linkListPriceNum(p: LinkListingPinProperties): number {
   return p.listPriceNum;
 }
 
-function linkMlsNeighborhood(mlsArea: string | null | undefined): string | null {
-  const s = mlsArea?.trim();
-  return s ? s : null;
+function parseListingDateMs(s: string | null | undefined): number | null {
+  if (!s?.trim()) return null;
+  const t = Date.parse(s);
+  return Number.isNaN(t) ? null : t;
+}
+
+/** Hero pill: active `For Sale | … days on market`; sold `Sold | … days on market` (list → close). */
+function formatRealEstateHeroPill(input: {
+  pool: "active" | "sold";
+  onMarketDate: string | null;
+  closeDate?: string | null;
+}): string {
+  const start = parseListingDateMs(input.onMarketDate);
+  if (input.pool === "active") {
+    if (start == null) return "For Sale | —";
+    const days = Math.max(0, Math.floor((Date.now() - start) / 86_400_000));
+    return `For Sale | ${days} ${days === 1 ? "day" : "days"} on market`;
+  }
+  const end = parseListingDateMs(input.closeDate);
+  if (start == null || end == null) return "Sold | —";
+  const days = Math.max(0, Math.floor((end - start) / 86_400_000));
+  return `Sold | ${days} ${days === 1 ? "day" : "days"} on market`;
+}
+
+function isLandOrCommercialPropertyType(propertyType: string | null | undefined): boolean {
+  const t = (propertyType ?? "").trim().toLowerCase();
+  if (!t) return false;
+  if (/\bcommercial\b/.test(t)) return true;
+  if (t === "land") return true;
+  if (t.includes("lots") && t.includes("land")) return true;
+  return false;
 }
 
 function rentalPulseRows(listPrice: number | null, weeklyRent: number | null) {
@@ -249,19 +280,19 @@ export function PropertyIntelligencePanel({
   const [watched, setWatched] = useState(false);
 
   useEffect(() => {
-    if (!parcelId) {
+    if (compactHero || !parcelId) {
       setWatched(false);
       return;
     }
     setWatched(parcelIsWatched(parcelId));
-  }, [parcelId]);
+  }, [compactHero, parcelId]);
 
   const onToggleWatch = useCallback(() => {
-    if (!parcelId) return;
+    if (compactHero || !parcelId) return;
     toggleWatchParcelId(parcelId);
     setWatched(parcelIsWatched(parcelId));
     onWatchChange?.();
-  }, [parcelId, onWatchChange]);
+  }, [compactHero, parcelId, onWatchChange]);
 
   const lotSqft = useMemo(() => {
     if (selectedParcel?.lot_area_sqft != null && selectedParcel.lot_area_sqft > 0) return selectedParcel.lot_area_sqft;
@@ -289,6 +320,14 @@ export function PropertyIntelligencePanel({
   }, [selectedRental?.weeklyRentEstimate, listPriceForPulse]);
 
   const timeline = useMemo(() => buildTimeline(selectedLink), [selectedLink]);
+
+  const comparableRentalsHref = useMemo(
+    () =>
+      nantucketRentalsComparableSearchUrlFromListingBedrooms(
+        selectedLink?.bedrooms ?? parcelLinkListingMatch?.bedrooms ?? selectedRental?.totalBedrooms ?? null,
+      ),
+    [selectedLink?.bedrooms, parcelLinkListingMatch?.bedrooms, selectedRental?.totalBedrooms],
+  );
 
   if (!has) {
     return (
@@ -367,18 +406,27 @@ export function PropertyIntelligencePanel({
       ? { lng: selectedRental.longitude, lat: selectedRental.latitude }
       : null;
 
-  const statusLabel =
-    selectedLink?.pool === "sold"
-      ? linkMlsNeighborhood(selectedLink.mlsArea) ?? "Sold"
-      : selectedLink
-        ? linkMlsNeighborhood(selectedLink.mlsArea) ?? "For sale"
-        : parcelLinkListingMatch?.pool === "sold"
-          ? linkMlsNeighborhood(parcelLinkListingMatch.mlsArea) ?? "Sold"
-          : parcelLinkListingMatch?.pool === "active"
-            ? linkMlsNeighborhood(parcelLinkListingMatch.mlsArea) ?? "For sale"
-            : selectedRental
-              ? "For rent"
-              : linkMlsNeighborhood(parcelLinkListingMatch?.mlsArea) ?? "Parcel";
+  const mlsPropertyTypeForRules =
+    selectedLink?.propertyType ?? parcelLinkListingMatch?.propertyType ?? null;
+
+  const statusLabel = selectedRental
+    ? "Vacation Rental"
+    : selectedLink
+      ? formatRealEstateHeroPill({
+          pool: selectedLink.pool,
+          onMarketDate: selectedLink.onMarketDate,
+          closeDate: selectedLink.closeDate?.trim() ? selectedLink.closeDate : null,
+        })
+      : parcelLinkListingMatch
+        ? formatRealEstateHeroPill({
+            pool: parcelLinkListingMatch.pool,
+            onMarketDate: parcelLinkListingMatch.onMarketDate,
+            closeDate: parcelLinkListingMatch.closeDate,
+          })
+        : "Parcel";
+
+  const pulse = rentalPulse;
+  const showRentalPulseBlock = Boolean(pulse) && !isLandOrCommercialPropertyType(mlsPropertyTypeForRules);
 
   const heroListingHref = (() => {
     if (selectedLink != null) return nantucketLinkListingUrl(selectedLink.linkId);
@@ -392,7 +440,14 @@ export function PropertyIntelligencePanel({
   })();
 
   return (
-    <div className="space-y-0 rounded-lg border border-[var(--cedar-shingle)]/20 bg-white shadow-sm">
+    <div
+      className={cn(
+        "space-y-0 bg-white shadow-sm",
+        compactHero
+          ? "rounded-b-xl border-b border-[var(--cedar-shingle)]/20"
+          : "rounded-lg border border-[var(--cedar-shingle)]/20",
+      )}
+    >
       <PropertyIntelligenceHero
         heroUrl={heroUrl}
         heroListingHref={heroListingHref}
@@ -424,21 +479,21 @@ export function PropertyIntelligencePanel({
           </p>
         ) : null}
 
-        {rentalPulse ? (
+        {showRentalPulseBlock && pulse ? (
           <section className="border-t border-[var(--cedar-shingle)]/15 pt-3">
             <h3 className="mb-2 text-[11px] font-bold uppercase tracking-wide text-[var(--atlantic-navy)]">Rental pulse</h3>
             <dl className="space-y-1 text-[11px]">
               <div className="flex justify-between gap-2">
                 <dt className="text-[var(--nantucket-gray)]">Peak weekly (Jul–Aug)</dt>
-                <dd className="font-medium text-[var(--atlantic-navy)]">{formatMoney(rentalPulse.peak)}</dd>
+                <dd className="font-medium text-[var(--atlantic-navy)]">{formatMoney(pulse.peak)}</dd>
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-[var(--nantucket-gray)]">Est. annual revenue</dt>
-                <dd className="font-medium text-[var(--atlantic-navy)]">{formatMoney(rentalPulse.annualRevenue)}</dd>
+                <dd className="font-medium text-[var(--atlantic-navy)]">{formatMoney(pulse.annualRevenue)}</dd>
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-[var(--nantucket-gray)]">Est. cap rate</dt>
-                <dd className="font-medium text-[var(--atlantic-navy)]">{rentalPulse.cap}</dd>
+                <dd className="font-medium text-[var(--atlantic-navy)]">{pulse.cap}</dd>
               </div>
             </dl>
             {expansion ? (
@@ -466,7 +521,9 @@ export function PropertyIntelligencePanel({
               </Button>
             ) : (
               <Button asChild variant="outline" className="mt-3 w-full text-xs">
-                <Link href="/map?mode=rent">View comparable rentals →</Link>
+                <a href={comparableRentalsHref} target="_blank" rel="noopener noreferrer">
+                  View comparable rentals →
+                </a>
               </Button>
             )}
           </section>
@@ -493,7 +550,9 @@ export function PropertyIntelligencePanel({
               </Button>
             ) : (
               <Button asChild variant="outline" className="mt-3 w-full text-xs">
-                <Link href="/map?mode=rent">View comparable rentals →</Link>
+                <a href={comparableRentalsHref} target="_blank" rel="noopener noreferrer">
+                  View comparable rentals →
+                </a>
               </Button>
             )}
           </section>

--- a/src/components/map/PropertyMapFiltersSheet.tsx
+++ b/src/components/map/PropertyMapFiltersSheet.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import Link from "next/link";
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import {
   Sheet,
@@ -36,6 +34,8 @@ export type MapFilterPinSummary = {
   linkSoldTotal: number;
 };
 
+type FilterSheetTab = "rent" | "sale" | "sold";
+
 type Props = {
   mapMode: PropertyMapMode;
   selectedModes?: Array<Exclude<PropertyMapMode, "all">>;
@@ -61,15 +61,18 @@ function Chip({
   onClick,
   children,
   className,
+  title,
 }: {
   selected: boolean;
   onClick: () => void;
   children: ReactNode;
   className?: string;
+  title?: string;
 }) {
   return (
     <button
       type="button"
+      title={title}
       onClick={onClick}
       className={cn(
         "rounded-full border px-2.5 py-1 text-[11px] font-semibold transition-colors",
@@ -105,7 +108,6 @@ export function PropertyMapFiltersSheet({
   side = "bottom",
 }: Props) {
   const [internalOpen, setInternalOpen] = useState(false);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
   const isControlled = openControlled !== undefined && onOpenChange !== undefined;
   const open = isControlled ? openControlled : internalOpen;
   const setOpen = (next: boolean) => {
@@ -114,11 +116,13 @@ export function PropertyMapFiltersSheet({
   };
 
   const selected = new Set<Exclude<PropertyMapMode, "all">>(
-    selectedModes?.length
-      ? selectedModes
-      : mapMode === "all"
-        ? ["rent", "sale", "sold"]
-        : [mapMode as Exclude<PropertyMapMode, "all">],
+    Array.isArray(selectedModes) && selectedModes.length === 0
+      ? []
+      : selectedModes?.length
+        ? selectedModes
+        : mapMode === "all"
+          ? ["rent", "sale", "sold"]
+          : [mapMode as Exclude<PropertyMapMode, "all">],
   );
   const showRent = selected.has("rent");
   const showSale = selected.has("sale");
@@ -126,10 +130,34 @@ export function PropertyMapFiltersSheet({
   const showLink = showSale || showSold;
   const showSoldTools = showSold;
 
-  const badge =
-    (showRent ? countActiveRentalFilters(rentalFilters) : 0) + (showLink ? countActiveLinkFilters(linkFilters) : 0);
+  const tabIds = useMemo((): FilterSheetTab[] => {
+    const ids: FilterSheetTab[] = [];
+    if (showRent) ids.push("rent");
+    if (showSale) ids.push("sale");
+    if (showSold) ids.push("sold");
+    return ids;
+  }, [showRent, showSale, showSold]);
+
+  const [activeTab, setActiveTab] = useState<FilterSheetTab>("rent");
+
+  useEffect(() => {
+    if (tabIds.length === 0) return;
+    if (!tabIds.includes(activeTab)) setActiveTab(tabIds[0]!);
+  }, [tabIds, activeTab]);
+
+  const rentBadge = showRent ? countActiveRentalFilters(rentalFilters) : 0;
+  const linkBadge = showLink ? countActiveLinkFilters(linkFilters) : 0;
+
+  const viewingRent = showRent && (tabIds.length === 1 ? tabIds[0] === "rent" : activeTab === "rent");
+  const viewingLink =
+    showLink && (tabIds.length === 1 ? tabIds[0] === "sale" || tabIds[0] === "sold" : activeTab === "sale" || activeTab === "sold");
+
+  const badge = rentBadge + linkBadge;
 
   const headline = useMemo(() => {
+    if (!showRent && !showSale && !showSold) {
+      return "No listing types selected — turn on For rent, For sale, and/or Sold above";
+    }
     const parts: string[] = [];
     if (showRent && !showLink) {
       parts.push(`${pinSummary.rentalsFiltered} rental${pinSummary.rentalsFiltered === 1 ? "" : "s"}`);
@@ -207,8 +235,52 @@ export function PropertyMapFiltersSheet({
             ) : null}
           </SheetHeader>
 
+          {tabIds.length > 1 ? (
+            <div
+              role="tablist"
+              aria-label="Listing type filters"
+              className="flex shrink-0 gap-0 border-b border-[var(--cedar-shingle)]/15 px-2"
+            >
+              {tabIds.map((id) => {
+                const selectedTab = activeTab === id;
+                const label = id === "rent" ? "Vacation Rentals" : id === "sale" ? "For sale" : "Sold";
+                const tabBadge =
+                  id === "rent" && rentBadge > 0 ? rentBadge : (id === "sale" || id === "sold") && linkBadge > 0 ? linkBadge : 0;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    role="tab"
+                    aria-selected={selectedTab}
+                    onClick={() => setActiveTab(id)}
+                    className={cn(
+                      "relative min-h-11 flex-1 px-2 py-2.5 text-center text-xs font-semibold transition-colors",
+                      selectedTab
+                        ? "text-blue-800 after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-blue-700"
+                        : "text-[var(--nantucket-gray)] hover:text-[var(--atlantic-navy)]",
+                    )}
+                  >
+                    <span className="inline-flex flex-col items-center gap-0.5">
+                      <span>{label}</span>
+                      {tabBadge > 0 ? (
+                        <span className="rounded-full bg-blue-700 px-1.5 py-px text-[10px] font-bold leading-none text-white">
+                          {tabBadge > 99 ? "99+" : tabBadge}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
           <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 py-4">
-            {showRent ? (
+            {tabIds.length === 0 ? (
+              <p className="rounded-md border border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)]/40 px-3 py-2 text-xs leading-snug text-[var(--atlantic-navy)]">
+                Select at least one listing type using the chips on the map toolbar to filter pins here.
+              </p>
+            ) : null}
+            {viewingRent ? (
               <section className="space-y-3">
                 <div className="flex items-center justify-between gap-2">
                   <SectionLabel>Vacation rentals</SectionLabel>
@@ -300,10 +372,21 @@ export function PropertyMapFiltersSheet({
               </section>
             ) : null}
 
-            {showLink ? (
-              <section className={cn("space-y-4", showRent && "border-t border-[var(--cedar-shingle)]/15 pt-5")}>
+            {viewingLink ? (
+              <section className="space-y-4">
+                {tabIds.length > 1 && (activeTab === "sale" || activeTab === "sold") ? (
+                  <p className="rounded-md border border-blue-700/10 bg-blue-50/60 px-2.5 py-1.5 text-[11px] leading-snug text-blue-950">
+                    {activeTab === "sale"
+                      ? showSold
+                        ? "Active MLS pins: criteria below also shape sold pins where the same field applies (e.g. price, beds). Sold close dates can be filtered below when sold pins are on."
+                        : "Criteria below apply to active MLS pins in the current map view."
+                      : showSale
+                        ? "Sold MLS pins: criteria below also shape active pins where the same field applies. Sold close dates are below."
+                        : "Criteria below apply to sold MLS pins in the current map view."}
+                  </p>
+                ) : null}
                 <div className="flex items-center justify-between gap-2">
-                  <SectionLabel>LINK listings</SectionLabel>
+                  <SectionLabel>MLS Listings</SectionLabel>
                   <span className="text-right text-[11px] font-medium leading-tight text-blue-900">
                     {showSale ? (
                       <span>
@@ -317,6 +400,28 @@ export function PropertyMapFiltersSheet({
                       </span>
                     ) : null}
                   </span>
+                </div>
+                <div>
+                  <p className="mb-1.5 text-[11px] font-medium text-[var(--atlantic-navy)]">Property type</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {LINK_PROPERTY_TYPE_LABELS.map(({ key, label }) => {
+                      const on = linkFilters.propertyTypes.includes(key);
+                      return (
+                        <Chip
+                          key={key}
+                          selected={on}
+                          onClick={() =>
+                            onLinkFiltersChange({
+                              ...linkFilters,
+                              propertyTypes: toggleTypeKey(linkFilters.propertyTypes, key),
+                            })
+                          }
+                        >
+                          {label}
+                        </Chip>
+                      );
+                    })}
+                  </div>
                 </div>
                 <div>
                   <p className="mb-1.5 text-[11px] font-medium text-[var(--atlantic-navy)]">Price</p>
@@ -344,55 +449,6 @@ export function PropertyMapFiltersSheet({
                         {label}
                       </Chip>
                     ))}
-                  </div>
-                </div>
-                <div>
-                  <p className="mb-1.5 text-[11px] font-medium text-[var(--atlantic-navy)]">Custom price</p>
-                  <div className="flex items-stretch overflow-hidden rounded-xl border border-[var(--cedar-shingle)]/25 bg-[var(--sandstone)]/30 shadow-inner">
-                    <div className="flex min-w-0 flex-1 flex-col border-r border-[var(--cedar-shingle)]/20 px-3 py-2">
-                      <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--nantucket-gray)]">Min</span>
-                      <Input
-                        inputMode="numeric"
-                        placeholder="$0"
-                        value={linkFilters.minPrice}
-                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, minPrice: e.target.value, pricePreset: "" })}
-                        className="h-8 border-0 bg-transparent p-0 text-sm font-semibold text-[var(--atlantic-navy)] focus-visible:ring-0"
-                      />
-                    </div>
-                    <div className="flex min-w-0 flex-1 flex-col px-3 py-2">
-                      <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--nantucket-gray)]">Max</span>
-                      <Input
-                        inputMode="numeric"
-                        placeholder="No max"
-                        value={linkFilters.maxPrice}
-                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, maxPrice: e.target.value, pricePreset: "" })}
-                        className="h-8 border-0 bg-transparent p-0 text-sm font-semibold text-[var(--atlantic-navy)] focus-visible:ring-0"
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div>
-                  <p className="mb-1.5 text-[11px] font-medium text-[var(--atlantic-navy)]">Value — max $/sqft</p>
-                  <p className="mb-1.5 text-[10px] text-[var(--nantucket-gray)]">Uses living area from LINK when present; other listings are hidden while this filter is on.</p>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Chip
-                      selected={linkFilters.maxPricePerSqft === "1500"}
-                      onClick={() =>
-                        onLinkFiltersChange({
-                          ...linkFilters,
-                          maxPricePerSqft: linkFilters.maxPricePerSqft === "1500" ? "" : "1500",
-                        })
-                      }
-                    >
-                      Under $1,500/sqft
-                    </Chip>
-                    <Input
-                      inputMode="decimal"
-                      placeholder="Custom max $/sqft"
-                      value={linkFilters.maxPricePerSqft}
-                      onChange={(e) => onLinkFiltersChange({ ...linkFilters, maxPricePerSqft: e.target.value })}
-                      className="h-9 max-w-[10rem] rounded-lg border-[var(--cedar-shingle)]/25 text-sm font-medium"
-                    />
                   </div>
                 </div>
                 <div className="grid gap-4 sm:grid-cols-2">
@@ -446,28 +502,6 @@ export function PropertyMapFiltersSheet({
                     ))}
                   </div>
                 </div>
-                <div>
-                  <p className="mb-1.5 text-[11px] font-medium text-[var(--atlantic-navy)]">Property type</p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {LINK_PROPERTY_TYPE_LABELS.map(({ key, label }) => {
-                      const on = linkFilters.propertyTypes.includes(key);
-                      return (
-                        <Chip
-                          key={key}
-                          selected={on}
-                          onClick={() =>
-                            onLinkFiltersChange({
-                              ...linkFilters,
-                              propertyTypes: toggleTypeKey(linkFilters.propertyTypes, key),
-                            })
-                          }
-                        >
-                          {label}
-                        </Chip>
-                      );
-                    })}
-                  </div>
-                </div>
                 <div className="flex flex-wrap gap-2 rounded-xl border border-[var(--cedar-shingle)]/15 bg-blue-50/40 p-2.5">
                   <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-xs font-medium text-[var(--atlantic-navy)] has-[:checked]:border-blue-700/30 has-[:checked]:bg-white">
                     <Checkbox
@@ -499,81 +533,51 @@ export function PropertyMapFiltersSheet({
                   </label>
                 </div>
 
-                <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      className="flex w-full items-center justify-between rounded-lg border border-[var(--cedar-shingle)]/25 bg-white px-3 py-2 text-left text-xs font-semibold text-[var(--atlantic-navy)] shadow-sm"
-                    >
-                      Advanced
-                      <span className="text-[var(--nantucket-gray)]">{advancedOpen ? "▾" : "▸"}</span>
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="space-y-3 border-b border-t border-[var(--cedar-shingle)]/10 py-3 data-[state=closed]:animate-out">
-                    <label className="flex cursor-pointer items-start gap-2 rounded-lg border border-blue-700/15 bg-blue-50/50 p-2.5">
-                      <Checkbox
-                        checked={linkFilters.highYieldZones}
-                        onCheckedChange={(v) => onLinkFiltersChange({ ...linkFilters, highYieldZones: v === true })}
-                        className="mt-0.5"
+                {showSoldTools ? (
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Sold — closed after</p>
+                      <Input
+                        type="date"
+                        value={linkFilters.soldCloseAfter}
+                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, soldCloseAfter: e.target.value })}
+                        className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
                       />
-                      <span>
-                        <span className="text-xs font-semibold text-[var(--atlantic-navy)]">Stephen Maury&apos;s high-yield zones</span>
-                        <span className="mt-0.5 block text-[10px] leading-snug text-[var(--nantucket-gray)]">
-                          Town, Brant Point, Cliff, Surfside, Sconset, Wauwinet, Dionis, Polpis, Madaket, and similar MLS
-                          area tags when present on the listing.
-                        </span>
-                      </span>
-                    </label>
-                    {showSoldTools ? (
-                      <div className="grid gap-3 sm:grid-cols-2">
-                        <div>
-                          <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Sold — closed after</p>
-                          <Input
-                            type="date"
-                            value={linkFilters.soldCloseAfter}
-                            onChange={(e) => onLinkFiltersChange({ ...linkFilters, soldCloseAfter: e.target.value })}
-                            className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
-                          />
-                        </div>
-                        <div>
-                          <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Sold — closed before</p>
-                          <Input
-                            type="date"
-                            value={linkFilters.soldCloseBefore}
-                            onChange={(e) => onLinkFiltersChange({ ...linkFilters, soldCloseBefore: e.target.value })}
-                            className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
-                          />
-                        </div>
-                      </div>
-                    ) : null}
-                    <div className="grid grid-cols-2 gap-2">
-                      <div>
-                        <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (min)</p>
-                        <Input
-                          inputMode="numeric"
-                          placeholder="Any"
-                          value={linkFilters.minDom}
-                          onChange={(e) => onLinkFiltersChange({ ...linkFilters, minDom: e.target.value })}
-                          className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
-                        />
-                      </div>
-                      <div>
-                        <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (max)</p>
-                        <Input
-                          inputMode="numeric"
-                          placeholder="Any"
-                          value={linkFilters.maxDom}
-                          onChange={(e) => onLinkFiltersChange({ ...linkFilters, maxDom: e.target.value })}
-                          className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
-                        />
-                      </div>
                     </div>
-                    <p className="text-[10px] leading-snug text-[var(--nantucket-gray)]">
-                      DOM uses LINK on-market date when the feed provides it; sold comps use close date as the end of the
-                      window.
-                    </p>
-                  </CollapsibleContent>
-                </Collapsible>
+                    <div>
+                      <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Sold — closed before</p>
+                      <Input
+                        type="date"
+                        value={linkFilters.soldCloseBefore}
+                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, soldCloseBefore: e.target.value })}
+                        className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
+                      />
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (min)</p>
+                    <Input
+                      inputMode="numeric"
+                      placeholder="Any"
+                      value={linkFilters.minDom}
+                      onChange={(e) => onLinkFiltersChange({ ...linkFilters, minDom: e.target.value })}
+                      className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (max)</p>
+                    <Input
+                      inputMode="numeric"
+                      placeholder="Any"
+                      value={linkFilters.maxDom}
+                      onChange={(e) => onLinkFiltersChange({ ...linkFilters, maxDom: e.target.value })}
+                      className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
+                    />
+                  </div>
+                </div>
               </section>
             ) : null}
           </div>
@@ -581,9 +585,6 @@ export function PropertyMapFiltersSheet({
           <SheetFooter className="shrink-0 flex-col gap-2 border-t border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)]/90 px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur-sm">
             <Button type="button" className="h-11 w-full bg-blue-700 text-[15px] font-semibold text-white hover:bg-blue-800" onClick={() => setOpen(false)}>
               Apply filters
-            </Button>
-            <Button type="button" variant="outline" className="h-10 w-full border-[var(--cedar-shingle)]/35 text-sm font-semibold" asChild>
-              <Link href="/buy">Save search &amp; get alerts</Link>
             </Button>
             <Button type="button" variant="ghost" className="h-9 w-full text-xs font-medium text-[var(--nantucket-gray)]" onClick={clearAll}>
               Clear all filters

--- a/src/components/map/PropertyMapLayerBar.tsx
+++ b/src/components/map/PropertyMapLayerBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Building2, CircleHelp, MapPinned, SlidersHorizontal } from "lucide-react";
+import { useState } from "react";
+import { Ban, Building2, ChevronDown, CircleHelp, MapPinned, SlidersHorizontal } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/components/ui/utils";
 import type { ParcelBaseMapLayer } from "@/components/zoning/ZoningMap";
@@ -23,27 +24,14 @@ function layerPillActiveSolid() {
   );
 }
 
-function layerPillActiveSoft() {
-  return cn(
-    layerPillBase,
-    "border-[var(--privet-green)]/40 bg-[var(--sandstone)] text-[var(--atlantic-navy)] hover:border-[var(--privet-green)]/55 hover:bg-[var(--fog-gray)]",
-  );
-}
-
 export function MapLayersHowToText() {
   return (
     <div className="space-y-2 text-xs leading-relaxed text-[var(--nantucket-gray)]">
       <p>
-        <span className="font-semibold text-[var(--atlantic-navy)]">Tax zoning</span> follows assessor district codes on each lot
-        (R-10, ROH, LUG…).
-      </p>
-      <p>
-        <span className="font-semibold text-[var(--atlantic-navy)]">LINK market areas</span> group neighborhoods the way buyers search
-        (Surfside, Town, Sconset…).
-      </p>
-      <p>
-        Turn <span className="font-semibold text-[var(--atlantic-navy)]">Zoning Districts</span> tint on to compare districts; turn it off
-        for a neutral basemap when pins need to stand out.
+        <span className="font-semibold text-[var(--atlantic-navy)]">MLS Areas</span> shows neighborhood-style polygons (Surfside, Town,
+        Sconset…). <span className="font-semibold text-[var(--atlantic-navy)]">Zoning</span> tints lots by assessor district code (R-10,
+        ROH, LUG…). <span className="font-semibold text-[var(--atlantic-navy)]">None</span> hides both overlays so pins stand out on a
+        neutral basemap.
       </p>
     </div>
   );
@@ -102,65 +90,110 @@ type LayerPillsProps = {
   filterBadgeCount: number;
 };
 
+const OVERLAY_OPTIONS = [
+  { layer: "re_market_areas" as const, label: "MLS Areas", icon: MapPinned },
+  { layer: "tax_zoning" as const, label: "Zoning", icon: Building2 },
+  { layer: "none" as const, label: "None", icon: Ban },
+];
+
+function overlayOptionLabel(layer: ParcelBaseMapLayer): string {
+  return OVERLAY_OPTIONS.find((o) => o.layer === layer)?.label ?? "Zoning";
+}
+
+type OverlayChipProps = {
+  parcelBaseLayer: ParcelBaseMapLayer;
+  onParcelBaseLayer: (v: ParcelBaseMapLayer) => void;
+  layout?: "row" | "stack";
+  /** Classes on outer wrapper (e.g. responsive visibility). */
+  className?: string;
+  /** Extra classes merged onto the trigger button. */
+  triggerClassName?: string;
+};
+
+/** Single control: shows `Overlay: …` and opens a menu for MLS Areas / Zoning / None. */
+export function PropertyMapOverlayChip({
+  parcelBaseLayer,
+  onParcelBaseLayer,
+  layout = "row",
+  className,
+  triggerClassName,
+}: OverlayChipProps) {
+  const [open, setOpen] = useState(false);
+  const currentLabel = overlayOptionLabel(parcelBaseLayer);
+
+  return (
+    <div className={cn(className)}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex shrink-0 items-center gap-1 rounded-full border border-[var(--cedar-shingle)]/35 bg-white/95 px-2.5 py-0.5 text-[11px] font-semibold normal-case text-[var(--atlantic-navy)] shadow-sm transition-colors hover:border-[var(--cedar-shingle)]/55 hover:bg-[var(--sandstone)]/90",
+              layout === "stack" && "w-full justify-center",
+              triggerClassName,
+            )}
+            aria-haspopup="dialog"
+            aria-expanded={open}
+            aria-label={`Map overlay: ${currentLabel}. Change overlay.`}
+          >
+            <span className="max-w-[11rem] truncate sm:max-w-[14rem]">
+              Overlay: {currentLabel}
+            </span>
+            <ChevronDown
+              className={cn("h-3.5 w-3.5 shrink-0 opacity-70 transition-transform", open && "rotate-180")}
+              aria-hidden
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-[min(100vw-2rem,14rem)] border-[var(--cedar-shingle)]/20 p-1" sideOffset={6}>
+          <p className="px-2 pb-1 pt-0.5 text-[10px] font-bold uppercase tracking-wide text-[var(--nantucket-gray)]">Overlay</p>
+          <div role="listbox" aria-label="Map overlay" className="flex flex-col gap-0.5">
+            {OVERLAY_OPTIONS.map(({ layer, label, icon: Icon }) => {
+              const selected = parcelBaseLayer === layer;
+              return (
+                <button
+                  key={layer}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => {
+                    onParcelBaseLayer(layer);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs font-medium transition-colors",
+                    selected
+                      ? "bg-blue-50 text-blue-950"
+                      : "text-[var(--atlantic-navy)] hover:bg-[var(--sandstone)]/80",
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5 shrink-0 opacity-80" aria-hidden />
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
 export function PropertyMapLayerPillsRow({
   layout = "row",
-  showZoningColors,
-  onShowZoningColors,
+  showZoningColors: _showZoningColors,
+  onShowZoningColors: _onShowZoningColors,
   parcelBaseLayer,
   onParcelBaseLayer,
   onOpenFilters,
   filterBadgeCount,
 }: LayerPillsProps) {
-  const taxSelected = parcelBaseLayer === "tax_zoning";
-  const linkMarketSelected = parcelBaseLayer === "re_market_areas";
-
-  const onZoningDistrictsClick = () => {
-    if (!taxSelected) {
-      onParcelBaseLayer("tax_zoning");
-      onShowZoningColors(true);
-      return;
-    }
-    onShowZoningColors(!showZoningColors);
-  };
-
-  const zoningTintOn = taxSelected && showZoningColors;
-  const zoningTaxNoTint = taxSelected && !showZoningColors;
-  const zoningPillClass = zoningTintOn ? layerPillActiveSolid() : zoningTaxNoTint ? layerPillActiveSoft() : layerPillInactive();
-
   const filtersActive = filterBadgeCount > 0;
-
-  const zoningIconClass = zoningTintOn
-    ? "text-white"
-    : zoningTaxNoTint
-      ? "text-[var(--privet-green)]"
-      : "text-[var(--cedar-shingle)]";
-  const marketIconClass = linkMarketSelected ? "text-white" : "text-[var(--cedar-shingle)]";
   const filtersIconClass = filtersActive ? "text-white" : "text-[var(--cedar-shingle)]";
 
   return (
     <div className={cn("flex gap-1.5", layout === "stack" ? "flex-col items-stretch" : "flex-row flex-wrap items-center")}>
-      <button
-        type="button"
-        onClick={onZoningDistrictsClick}
-        className={cn(zoningPillClass, layout === "stack" && "justify-center")}
-        aria-pressed={taxSelected}
-        title={taxSelected && !showZoningColors ? "Tax lots — tap again for district colors" : undefined}
-      >
-        <Building2 className={cn("h-3.5 w-3.5 shrink-0 stroke-[2]", zoningIconClass)} aria-hidden />
-        Zoning
-      </button>
-      <button
-        type="button"
-        onClick={() => onParcelBaseLayer("re_market_areas")}
-        className={cn(
-          linkMarketSelected ? layerPillActiveSolid() : layerPillInactive(),
-          layout === "stack" && "justify-center",
-        )}
-        aria-pressed={linkMarketSelected}
-      >
-        <MapPinned className={cn("h-3.5 w-3.5 shrink-0 stroke-[2]", marketIconClass)} aria-hidden />
-        Market
-      </button>
+      <PropertyMapOverlayChip parcelBaseLayer={parcelBaseLayer} onParcelBaseLayer={onParcelBaseLayer} layout={layout} />
       <button
         type="button"
         onClick={onOpenFilters}

--- a/src/components/zoning/ZoningLookupClient.tsx
+++ b/src/components/zoning/ZoningLookupClient.tsx
@@ -32,7 +32,11 @@ import {
 } from "@/lib/link-listings-parcel-match";
 import type { NrMapRentalResult, RentalPinFeature } from "@/lib/nr-map-rentals";
 import { rentalsToGeoJson } from "@/lib/nr-map-rentals";
-import { nantucketVacationRentalListingUrl } from "@/lib/nr-vacation-rental-url";
+import {
+  nantucketRentalsComparableSearchUrlFromListingBedrooms,
+  nantucketRentalsPropertySearchUrl,
+  nantucketVacationRentalListingUrl,
+} from "@/lib/nr-vacation-rental-url";
 import {
   applyRentalFilters,
   countActiveLinkFilters,
@@ -48,7 +52,7 @@ import { PropertyMapFiltersSheet } from "@/components/map/PropertyMapFiltersShee
 import {
   PropertyMapDesktopLayerBar,
   PropertyMapLayerHelpTrigger,
-  PropertyMapLayerPillsRow,
+  PropertyMapOverlayChip,
   ZoningLookupColorsStrip,
 } from "@/components/map/PropertyMapLayerBar";
 import { MapLegalNoticeButton } from "@/components/map/MapLegalNoticeButton";
@@ -81,23 +85,27 @@ type SelectableMapMode = Exclude<PropertyMapMode, "all">;
 const EMPTY_LINK_FC: FeatureCollection<Point, LinkListingPinProperties> = { type: "FeatureCollection", features: [] };
 
 function parseMapModes(v: string | null): SelectableMapMode[] {
-  if (!v) return ["rent"];
-  if (v === "all") return ["rent", "sale", "sold"];
+  if (v == null) return ["rent"];
+  const t = v.trim();
+  if (t === "" || t === "none") return [];
+  if (t === "all") return ["rent", "sale", "sold"];
   const parts = v
     .split(",")
     .map((x) => x.trim())
     .filter((x): x is SelectableMapMode => x === "rent" || x === "sale" || x === "sold");
   const unique = Array.from(new Set(parts));
-  return unique.length ? unique : ["rent"];
+  return unique.length ? unique : [];
 }
 
 function serializeMapModes(modes: SelectableMapMode[]): string {
   const uniq = Array.from(new Set(modes));
+  if (!uniq.length) return "none";
   const order: SelectableMapMode[] = ["sale", "rent", "sold"];
   return order.filter((m) => uniq.includes(m)).join(",");
 }
 
 function effectiveModeForOmnibox(modes: SelectableMapMode[]): PropertyMapMode {
+  if (modes.length === 0) return "all";
   const hasRent = modes.includes("rent");
   const hasSale = modes.includes("sale");
   const hasSold = modes.includes("sold");
@@ -438,6 +446,12 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
   > | null>(null);
   const [parcelBaseLayer, setParcelBaseLayer] = useState<ParcelBaseMapLayer>("tax_zoning");
   const [reMarketAreaAbbrv, setReMarketAreaAbbrv] = useState<string>("");
+  const applyParcelBaseLayer = useCallback((next: ParcelBaseMapLayer) => {
+    setParcelBaseLayer(next);
+    if (next !== "re_market_areas") setReMarketAreaAbbrv("");
+    if (next === "tax_zoning") setShowZoningColors(true);
+    else if (next === "none") setShowZoningColors(false);
+  }, []);
   const [mobileDrawerTab, setMobileDrawerTab] = useState<"rental" | "parcel">("rental");
   const [, setWatchTick] = useState(0);
   const [rentalFilters, setRentalFilters] = useState<RentalFiltersState>(() => ({ ...DEFAULT_RENTAL_FILTERS }));
@@ -448,6 +462,15 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
   const hasSaleMode = mapModes.includes("sale");
   const hasSoldMode = mapModes.includes("sold");
   const mapModeForOmnibox = effectiveModeForOmnibox(mapModes);
+
+  const mapResearchHubPrimaryCta = useMemo(() => {
+    if (!selectedRental) return null;
+    const slug = selectedRental.slug?.trim();
+    return {
+      primaryCtaLabel: "Check Availability" as const,
+      primaryCtaHref: slug ? nantucketVacationRentalListingUrl(slug) : nantucketRentalsPropertySearchUrl({}),
+    };
+  }, [selectedRental]);
 
   useEffect(() => {
     setMapModes(parseMapModes(searchParams.get("mode")));
@@ -463,7 +486,6 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
   const setMapModesAndUrl = useCallback(
     (nextModes: SelectableMapMode[]) => {
       const normalized = Array.from(new Set(nextModes));
-      if (!normalized.length) return;
       setMapModes(normalized);
       const sp = new URLSearchParams(searchParams.toString());
       sp.set("mode", serializeMapModes(normalized));
@@ -476,7 +498,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
     (mode: SelectableMapMode) => {
       setMapModes((prev) => {
         const exists = prev.includes(mode);
-        const next = exists ? (prev.length > 1 ? prev.filter((m) => m !== mode) : prev) : [...prev, mode];
+        const next = exists ? prev.filter((m) => m !== mode) : [...prev, mode];
         const normalized = Array.from(new Set(next));
         const sp = new URLSearchParams(searchParams.toString());
         sp.set("mode", serializeMapModes(normalized));
@@ -1090,29 +1112,14 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
   );
 
   const handleViewComparableRentals = useCallback(() => {
-    selectMapMode("rent");
-    setRentalFilters({ ...DEFAULT_RENTAL_FILTERS });
-    setSelectedLink(null);
-    const pid = String(selectedParcel?.parcel_id ?? "").trim();
-    const feat = features.find((f) => String(f.properties?.parcel_id ?? "").trim() === pid);
-    const geom = feat?.geometry;
-    if (geom) {
-      const c = centroidFromGeometry(geom);
-      if (c) {
-        const pad = 0.022;
-        setMapFlyTo({
-          id: bumpFlyId(),
-          bounds: {
-            west: c.lng - pad,
-            east: c.lng + pad,
-            south: c.lat - pad,
-            north: c.lat + pad,
-          },
-        });
-      }
-    }
-    if (isNarrowForParcelDrawer()) setMobilePanelOpen(false);
-  }, [features, selectMapMode, selectedParcel?.parcel_id]);
+    const baseBedrooms =
+      selectedLink?.bedrooms ??
+      effectiveParcelLinkMatch?.bedrooms ??
+      selectedRental?.totalBedrooms ??
+      null;
+    const url = nantucketRentalsComparableSearchUrlFromListingBedrooms(baseBedrooms);
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [selectedLink?.bedrooms, effectiveParcelLinkMatch?.bedrooms, selectedRental?.totalBedrooms]);
 
   const handleViewNearbySales = useCallback(() => {
     selectMapMode("sold");
@@ -1340,28 +1347,12 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                     </button>
                   ))}
                 </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setParcelBaseLayer((prev) => {
-                      const next = prev === "tax_zoning" ? "re_market_areas" : "tax_zoning";
-                      if (next === "tax_zoning") {
-                        setShowZoningColors(true);
-                        setReMarketAreaAbbrv("");
-                      }
-                      return next;
-                    });
-                  }}
-                  className={cn(
-                    "inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors sm:px-3 sm:py-1 sm:text-sm lg:hidden",
-                    parcelBaseLayer === "re_market_areas"
-                      ? "border-blue-700 bg-blue-700 text-white shadow-sm"
-                      : "border-[var(--cedar-shingle)]/30 bg-white/90 text-[var(--atlantic-navy)] hover:bg-[var(--sandstone)]",
-                  )}
-                  aria-label="Toggle map base layer"
-                >
-                  {parcelBaseLayer === "tax_zoning" ? "Show MLS Areas" : "Show Zoning Districts"}
-                </button>
+                <PropertyMapOverlayChip
+                  className="shrink-0 lg:hidden"
+                  triggerClassName="px-2 py-0.5 sm:px-2.5 sm:py-1 sm:text-sm"
+                  parcelBaseLayer={parcelBaseLayer}
+                  onParcelBaseLayer={applyParcelBaseLayer}
+                />
                 <button
                   type="button"
                   onClick={() => setFiltersOpen(true)}
@@ -1377,23 +1368,12 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   ) : null}
                 </button>
               </div>
-              <div className="hidden min-w-0 items-center gap-2 overflow-x-auto pb-0.5 [-ms-overflow-style:none] [scrollbar-width:none] lg:hidden [&::-webkit-scrollbar]:hidden">
-                <PropertyMapLayerPillsRow
-                  layout="row"
-                  showZoningColors={showZoningColors}
-                  onShowZoningColors={setShowZoningColors}
-                  parcelBaseLayer={parcelBaseLayer}
-                  onParcelBaseLayer={setParcelBaseLayer}
-                  onOpenFilters={() => setFiltersOpen(true)}
-                  filterBadgeCount={filterBadgeCount}
-                />
-              </div>
               <div className="hidden min-w-0 lg:block">
                 <PropertyMapDesktopLayerBar
                   showZoningColors={showZoningColors}
                   onShowZoningColors={setShowZoningColors}
                   parcelBaseLayer={parcelBaseLayer}
-                  onParcelBaseLayer={setParcelBaseLayer}
+                  onParcelBaseLayer={applyParcelBaseLayer}
                   reMarketAreaAbbrv={reMarketAreaAbbrv}
                   onReMarketAreaChange={setReMarketAreaAbbrv}
                   onRequestFlyToReDistrict={(abbrv) => {
@@ -1781,15 +1761,15 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   {hasSaleMode && hasSoldMode ? (
                     <>
                       Showing <strong>{filteredLinkActiveFc.features.length}</strong> active and{" "}
-                      <strong>{filteredLinkSoldFc.features.length}</strong> sold LINK listings matching your criteria in this view • Live MLS feed.
+                      <strong>{filteredLinkSoldFc.features.length}</strong> sold MLS listings matching your criteria in this view • Live MLS feed.
                     </>
                   ) : hasSaleMode ? (
                     <>
-                      Showing <strong>{filteredLinkActiveFc.features.length}</strong> active LINK listings matching your criteria in this view • Live MLS feed.
+                      Showing <strong>{filteredLinkActiveFc.features.length}</strong> active MLS listings matching your criteria in this view • Live MLS feed.
                     </>
                   ) : (
                     <>
-                      Showing <strong>{filteredLinkSoldFc.features.length}</strong> sold LINK listings matching your criteria in this view • Live MLS feed.
+                      Showing <strong>{filteredLinkSoldFc.features.length}</strong> sold MLS listings matching your criteria in this view • Live MLS feed.
                     </>
                   )}
                 </p>
@@ -1824,15 +1804,15 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                     {hasSaleMode && hasSoldMode ? (
                       <>
                         Showing <strong>{filteredLinkActiveFc.features.length}</strong> active and{" "}
-                        <strong>{filteredLinkSoldFc.features.length}</strong> sold LINK listings matching your criteria in this view • Live MLS feed.
+                        <strong>{filteredLinkSoldFc.features.length}</strong> sold MLS listings matching your criteria in this view • Live MLS feed.
                       </>
                     ) : hasSaleMode ? (
                       <>
-                        Showing <strong>{filteredLinkActiveFc.features.length}</strong> active LINK listings matching your criteria in this view • Live MLS feed.
+                        Showing <strong>{filteredLinkActiveFc.features.length}</strong> active MLS listings matching your criteria in this view • Live MLS feed.
                       </>
                     ) : (
                       <>
-                        Showing <strong>{filteredLinkSoldFc.features.length}</strong> sold LINK listings matching your criteria in this view • Live MLS feed.
+                        Showing <strong>{filteredLinkSoldFc.features.length}</strong> sold MLS listings matching your criteria in this view • Live MLS feed.
                       </>
                     )}
                   </p>
@@ -1953,7 +1933,10 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                 </div>
               ) : null}
                 </div>
-                <MapResearchHubStickyFooter className="border-t border-[var(--cedar-shingle)]/20 bg-white/90 px-2 pb-2 pt-3 backdrop-blur-sm" />
+                <MapResearchHubStickyFooter
+                  className="border-t border-[var(--cedar-shingle)]/20 bg-white/90 px-2 pb-2 pt-3 backdrop-blur-sm"
+                  {...(mapResearchHubPrimaryCta ?? {})}
+                />
               </div>
             ) : (
               <div className="min-h-0 flex-1 overflow-y-auto">
@@ -2000,7 +1983,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
             {isPropertyMap ? (
-              <div className="space-y-4 p-4">
+              <div className="flex flex-col pb-4">
                 <PropertyIntelligencePanel
                   compactHero
                   selectedParcel={selectedParcel}
@@ -2016,17 +1999,19 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   onViewComparableRentals={handleViewComparableRentals}
                 />
                 {selectedParcel ? (
-                  <ParcelDetailPanel
-                    {...parcelMapCtas}
-                    selectedParcel={selectedParcel}
-                    zoningLabel={zoningLabel}
-                    districtMatch={districtMatch}
-                    zoningUseRows={zoningUseRows}
-                    linkListingId={linkListingIdForSelection}
-                    vacationRentalSlug={vacationRentalSlugForSelection}
-                  />
+                  <div className="space-y-4 px-4 pt-4">
+                    <ParcelDetailPanel
+                      {...parcelMapCtas}
+                      selectedParcel={selectedParcel}
+                      zoningLabel={zoningLabel}
+                      districtMatch={districtMatch}
+                      zoningUseRows={zoningUseRows}
+                      linkListingId={linkListingIdForSelection}
+                      vacationRentalSlug={vacationRentalSlugForSelection}
+                    />
+                  </div>
                 ) : selectedRental ? (
-                  <p className="rounded-md border border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)]/40 px-3 py-2 text-center text-xs text-[var(--nantucket-gray)]">
+                  <p className="mx-4 mt-4 rounded-md border border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)]/40 px-3 py-2 text-center text-xs text-[var(--nantucket-gray)]">
                     This vacation rental pin did not match a loaded tax parcel. Zoom to Nantucket or tap a lot on the map
                     for full parcel and zoning detail.
                   </p>
@@ -2231,7 +2216,12 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
           </div>
           {isPropertyMap ? (
             <DrawerFooter className="mt-0 shrink-0 gap-0 border-t border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)] p-0 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
-              <MapResearchHubStickyFooter className="px-3 pt-3" />
+              <MapResearchHubStickyFooter
+                showContactLinks={false}
+                showLegalNav={false}
+                className="px-3 pt-3"
+                {...(mapResearchHubPrimaryCta ?? {})}
+              />
             </DrawerFooter>
           ) : null}
         </DrawerContent>

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -17,7 +17,8 @@ import {
 import { mapboxZoningFillColorExpression } from "@/lib/zoning-colors";
 import { reDistrictFillColorExpression, reDistrictPolygonsToBoundaryLines } from "@/lib/re-districts-map";
 
-export type ParcelBaseMapLayer = "tax_zoning" | "re_market_areas";
+/** Parcel fill + optional RE (MLS-style) market polygons under parcels. */
+export type ParcelBaseMapLayer = "tax_zoning" | "re_market_areas" | "none";
 
 export type ParcelProperties = {
   parcel_id?: string | null;
@@ -71,7 +72,7 @@ type ZoningMapProps = {
     | { id: number; lng: number; lat: number; zoom: number }
     | { id: number; bounds: { west: number; south: number; east: number; north: number } }
     | null;
-  /** LINK-style market polygons (RE_Districts). Shown when `parcelBaseLayer` is `re_market_areas`. */
+  /** MLS-style market polygons (RE_Districts). Shown when `parcelBaseLayer` is `re_market_areas`. */
   reDistrictsGeoJson?: FeatureCollection<Geometry, { Abbrv?: string; District?: string }> | null;
   parcelBaseLayer?: ParcelBaseMapLayer;
   /** Dim other market areas when set (Abbrv, e.g. SURF). */
@@ -207,10 +208,11 @@ function syncParcelAndReOverlay(
     map.setPaintProperty("parcels-fill", "fill-color", PARCEL_FILL_NEUTRAL);
     map.setPaintProperty("parcels-fill", "fill-opacity", 0);
   } else {
+    const zoningTint = opts.parcelBaseLayer === "tax_zoning" && opts.showZoningColors;
     map.setPaintProperty(
       "parcels-fill",
       "fill-color",
-      opts.showZoningColors ? mapboxZoningFillColorExpression() : PARCEL_FILL_NEUTRAL,
+      zoningTint ? mapboxZoningFillColorExpression() : PARCEL_FILL_NEUTRAL,
     );
     map.setPaintProperty("parcels-fill", "fill-opacity", PARCEL_FILL_OPACITY_HOVER);
   }

--- a/src/lib/link-listings-parcel-match.ts
+++ b/src/lib/link-listings-parcel-match.ts
@@ -228,8 +228,16 @@ export type ParcelMapLinkListingMatch = {
   listPriceNum: number;
   /** Formatted close price when sold. */
   closePrice: string;
+  /** ISO-ish MLS on-market date when present (DOM). */
+  onMarketDate: string | null;
+  /** Close date when sold (DOM through close). */
+  closeDate: string | null;
   /** MLS area / neighborhood (e.g. Tom Nevers). */
   mlsArea: string | null;
+  /** LINK MLS property type (e.g. Single Family, Land, Commercial). */
+  propertyType: string | null;
+  /** MLS bedrooms when present (for deep links to NR search). */
+  bedrooms: number | null;
   /** Pin / parcel centroid (for map hero framing). */
   longitude?: number | null;
   latitude?: number | null;
@@ -244,7 +252,11 @@ export function parcelMapListingMatchFromMapPoint(p: LinkListingMapPoint): Parce
     listPrice: formatMoney(p.listPrice),
     listPriceNum: p.listPrice,
     closePrice: p.closePrice != null ? formatMoney(p.closePrice) : "",
+    onMarketDate: p.onMarketDate,
+    closeDate: p.closeDate?.trim() ? p.closeDate : null,
     mlsArea: p.mlsArea,
+    propertyType: p.propertyType ?? null,
+    bedrooms: p.bedrooms ?? null,
     longitude: p.longitude,
     latitude: p.latitude,
   };
@@ -260,7 +272,11 @@ function featureToParcelMatch(f: Feature<Point, LinkListingPinProperties>): Parc
     listPrice: p.listPrice,
     listPriceNum: p.listPriceNum,
     closePrice: p.closePrice,
+    onMarketDate: p.onMarketDate,
+    closeDate: p.closeDate?.trim() ? p.closeDate : null,
     mlsArea: p.mlsArea,
+    propertyType: p.propertyType ?? null,
+    bedrooms: p.bedrooms ?? null,
     longitude: p.longitude ?? lng,
     latitude: p.latitude ?? lat,
   };

--- a/src/lib/map-rentals-inventory-cache.ts
+++ b/src/lib/map-rentals-inventory-cache.ts
@@ -1,0 +1,169 @@
+import { unstable_cache } from "next/cache";
+import type { NrMapRentalResult } from "@/lib/nr-map-rentals";
+
+const MAP_RENTALS_INVENTORY_TAG = "map-rentals-inventory";
+/** Full NR listing pagination is expensive; refresh in the background on this interval. */
+export const MAP_RENTALS_INVENTORY_REVALIDATE_SECONDS = 300;
+
+function getNrListingsApiBase(): string {
+  const raw = process.env.NR_LISTINGS_API_BASE ?? "https://api.nantucketrentals.com/api";
+  return raw.trim().replace(/\/$/, "");
+}
+
+type NrListingRow = {
+  nrPropertyId?: number;
+  slug?: string;
+  streetAddress?: string;
+  headline?: string;
+  latitude?: number;
+  longitude?: number;
+  status?: string;
+  NrPropertyPics?: { nrPropertyPicPath?: string }[];
+  NrRentalRates?: { propertyWeeklyRentInteger?: number; propertyWeeklyRent?: number }[];
+  averageNightlyRate?: number;
+  totalBedrooms?: number;
+  totalBathrooms?: number;
+  totalCapacity?: number;
+  hasPool?: boolean;
+  walkToBeach?: boolean;
+  highlights?: string | null;
+};
+
+function deriveWeeklyRent(row: NrListingRow): number | null {
+  const rates = row.NrRentalRates ?? [];
+  const ints = rates
+    .map((r) => r.propertyWeeklyRentInteger ?? r.propertyWeeklyRent)
+    .filter((n): n is number => typeof n === "number" && !Number.isNaN(n) && n > 0);
+  if (ints.length) return Math.round(Math.max(...ints));
+  const nightly = row.averageNightlyRate;
+  if (typeof nightly === "number" && !Number.isNaN(nightly) && nightly > 0) return Math.round(nightly * 7);
+  return null;
+}
+
+function textBlob(row: NrListingRow): string {
+  return [row.headline, row.streetAddress, row.slug, row.highlights].filter(Boolean).join(" ");
+}
+
+function petFriendlyHint(row: NrListingRow): boolean {
+  return /\b(pet|pets|dog|dogs|cat|cats)\b/i.test(textBlob(row));
+}
+
+function waterfrontHint(row: NrListingRow): boolean {
+  return /\b(waterfront|oceanfront|harbor|harbour|sound front|on the water|water view|beachfront)\b/i.test(
+    textBlob(row),
+  );
+}
+
+function renovatedHint(row: NrListingRow): boolean {
+  return /\b(renovated|renovation|fully updated|gut renovated|like new|newly renovated|designer|restored)\b/i.test(
+    textBlob(row),
+  );
+}
+
+function townWalkHint(row: NrListingRow): boolean {
+  return /\b(downtown|in town|in-town|town center|center of town|historic district|main street|steps to town|walk to town)\b/i.test(
+    textBlob(row),
+  );
+}
+
+function inBbox(lng: number, lat: number, west: number, south: number, east: number, north: number): boolean {
+  return lng >= west && lng <= east && lat >= south && lat <= north;
+}
+
+async function fetchAllActiveNrRowsFromUpstream(): Promise<NrListingRow[]> {
+  const base = getNrListingsApiBase();
+  const collected: NrListingRow[] = [];
+  let nextUrl: string | null = `${base}/property/nrproperty-listing/?page=1&page_size=500`;
+
+  while (nextUrl) {
+    const res = await fetch(nextUrl, {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      throw new Error(`Listings upstream ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as { results?: NrListingRow[]; next?: string | null };
+    for (const row of body.results ?? []) {
+      if ((row.status ?? "").toLowerCase() === "active") collected.push(row);
+    }
+    nextUrl = body.next ?? null;
+  }
+
+  return collected;
+}
+
+const getCachedActiveNrRows = unstable_cache(
+  fetchAllActiveNrRowsFromUpstream,
+  ["map-rentals-full-inventory"],
+  {
+    revalidate: MAP_RENTALS_INVENTORY_REVALIDATE_SECONDS,
+    tags: [MAP_RENTALS_INVENTORY_TAG],
+  },
+);
+
+function mapRowsToResults(
+  rows: NrListingRow[],
+  west: number,
+  south: number,
+  east: number,
+  north: number,
+): NrMapRentalResult[] {
+  const results: NrMapRentalResult[] = [];
+  for (const row of rows) {
+    const id = row.nrPropertyId;
+    const slug = row.slug?.trim();
+    const lat = row.latitude;
+    const lng = row.longitude;
+    if (id == null || !slug || lat == null || lng == null || Number.isNaN(lat) || Number.isNaN(lng)) continue;
+    if (!inBbox(lng, lat, west, south, east, north)) continue;
+    const thumb = row.NrPropertyPics?.[0]?.nrPropertyPicPath ?? null;
+    results.push({
+      nrPropertyId: id,
+      slug,
+      streetAddress: String(row.streetAddress ?? "").trim() || slug,
+      headline: String(row.headline ?? row.streetAddress ?? slug).trim(),
+      latitude: lat,
+      longitude: lng,
+      thumbUrl: thumb,
+      weeklyRentEstimate: deriveWeeklyRent(row),
+      totalBedrooms: typeof row.totalBedrooms === "number" ? row.totalBedrooms : null,
+      totalBathrooms: typeof row.totalBathrooms === "number" ? row.totalBathrooms : null,
+      totalCapacity: typeof row.totalCapacity === "number" ? row.totalCapacity : null,
+      hasPool: Boolean(row.hasPool),
+      walkToBeach: Boolean(row.walkToBeach),
+      averageNightlyRate: typeof row.averageNightlyRate === "number" ? row.averageNightlyRate : null,
+      petFriendlyHint: petFriendlyHint(row),
+      waterfrontHint: waterfrontHint(row),
+      renovatedHint: renovatedHint(row),
+      townWalkHint: townWalkHint(row),
+    });
+  }
+  return results;
+}
+
+/**
+ * Active NR rows for the whole catalog, served from Next data cache (see revalidate + tags).
+ * Bbox filtering stays cheap in memory per request.
+ */
+export async function getMapRentalResultsForBbox(
+  west: number,
+  south: number,
+  east: number,
+  north: number,
+): Promise<{ results: NrMapRentalResult[]; inventoryError: boolean }> {
+  try {
+    const rows = await getCachedActiveNrRows();
+    return { results: mapRowsToResults(rows, west, south, east, north), inventoryError: false };
+  } catch {
+    return { results: [], inventoryError: true };
+  }
+}
+
+/** Populate / refresh the cached full inventory (e.g. Vercel Cron). */
+export async function warmMapRentalsInventory(): Promise<{ count: number }> {
+  const rows = await getCachedActiveNrRows();
+  return { count: rows.length };
+}
+
+export { MAP_RENTALS_INVENTORY_TAG };

--- a/src/lib/nr-vacation-rental-url.ts
+++ b/src/lib/nr-vacation-rental-url.ts
@@ -1,6 +1,35 @@
+function nantucketRentalsWebOrigin(): string {
+  return (process.env.NEXT_PUBLIC_NR_RENTALS_WEB_ORIGIN ?? "https://www.nantucketrentals.com").replace(/\/$/, "");
+}
+
 /** Public Nantucket Rentals listing URL by site slug (same path as nr-web-fe `/${slug}`). */
 export function nantucketVacationRentalListingUrl(slug: string): string {
   const s = slug.trim().replace(/^\/+/, "");
-  const origin = (process.env.NEXT_PUBLIC_NR_RENTALS_WEB_ORIGIN ?? "https://www.nantucketrentals.com").replace(/\/$/, "");
-  return `${origin}/${encodeURIComponent(s)}`;
+  return `${nantucketRentalsWebOrigin()}/${encodeURIComponent(s)}`;
+}
+
+/**
+ * NR marketing site property search (`nr-web-fe` `/property-search`).
+ * `bedrooms` in the URL becomes `bedroom_min` on the listings API (see `getListingSearchQueriesFromURL`).
+ */
+export function nantucketRentalsPropertySearchUrl(params: { minBedrooms?: number | null }): string {
+  const origin = nantucketRentalsWebOrigin();
+  const sp = new URLSearchParams();
+  if (params.minBedrooms != null && params.minBedrooms >= 1) {
+    sp.set("bedrooms", String(Math.floor(params.minBedrooms)));
+  }
+  const q = sp.toString();
+  return `${origin}/property-search${q ? `?${q}` : ""}`;
+}
+
+/**
+ * Comparable vacation rental search: `bedrooms` = listing bedroom count + 1 (minimum 1).
+ * Omits `bedrooms` when the listing count is unknown.
+ */
+export function nantucketRentalsComparableSearchUrlFromListingBedrooms(
+  baseBedrooms: number | null | undefined,
+): string {
+  const b = baseBedrooms != null && Number.isFinite(Number(baseBedrooms)) ? Math.floor(Number(baseBedrooms)) : null;
+  const minBedrooms = b != null ? Math.max(1, b + 1) : null;
+  return nantucketRentalsPropertySearchUrl({ minBedrooms });
 }

--- a/src/lib/property-map-filters.ts
+++ b/src/lib/property-map-filters.ts
@@ -22,7 +22,7 @@ export type RentalFiltersState = {
   townWalk: boolean;
 };
 
-export type LinkPropertyTypeKey = "sf" | "condo" | "land" | "guest" | "multi";
+export type LinkPropertyTypeKey = "houses" | "land" | "commercial";
 
 export type LinkFiltersState = {
   pricePreset: "" | "1-3" | "3-6" | "6+";
@@ -37,8 +37,6 @@ export type LinkFiltersState = {
   walkToTown: boolean;
   /** Recently renovated / like-new (remarks heuristic). */
   renoRecent: boolean;
-  /** Curated MLS areas (Surfside, Town, Brant Point, …). */
-  highYieldZones: boolean;
   propertyTypes: LinkPropertyTypeKey[];
   /** yyyy-mm-dd inclusive lower bound on sold close date (sold pool). */
   soldCloseAfter: string;
@@ -76,7 +74,6 @@ export const DEFAULT_LINK_FILTERS: LinkFiltersState = {
   waterfront: false,
   walkToTown: false,
   renoRecent: false,
-  highYieldZones: false,
   propertyTypes: [],
   soldCloseAfter: "",
   soldCloseBefore: "",
@@ -85,52 +82,50 @@ export const DEFAULT_LINK_FILTERS: LinkFiltersState = {
   maxPricePerSqft: "",
 };
 
+/** MLS-facing labels for the map LINK property-type chips (sale/sold pools). */
 export const LINK_PROPERTY_TYPE_LABELS: { key: LinkPropertyTypeKey; label: string }[] = [
-  { key: "sf", label: "Single Family" },
-  { key: "condo", label: "Condo / Townhouse" },
+  { key: "houses", label: "Houses" },
   { key: "land", label: "Land" },
-  { key: "guest", label: "Guest / Carriage" },
-  { key: "multi", label: "Multi-Family" },
+  { key: "commercial", label: "Commercial" },
 ];
 
-export function isHighYieldMlsArea(area: string | null | undefined): boolean {
-  if (!area?.trim()) return false;
-  const a = area.toLowerCase();
-  const needles = [
-    "town",
-    "brant",
-    "cliff",
-    "surfside",
-    "sconset",
-    "siasconset",
-    "wauwinet",
-    "quent",
-    "dionis",
-    "polpis",
-    "quidnet",
-    "pocomo",
-    "madaket",
-    "shimmo",
-  ];
-  return needles.some((n) => a.includes(n));
+function linkPropertyTypeIsLand(low: string): boolean {
+  return /\b(land|lot|lots|acre|unimproved|vacant land|lots\s*[\/&]\s*land|agricultural|farm)\b/i.test(low);
+}
+
+function linkPropertyTypeIsCommercial(low: string): boolean {
+  return /\b(commercial|industrial|retail|office|warehouse|hospitality|hotel|motel|mixed.?use|business|medical|restaurant)\b/i.test(
+    low,
+  );
+}
+
+/** Dwelling / residential inventory that is not land-only or commercial. */
+function linkPropertyTypeIsHouses(low: string): boolean {
+  if (!low.trim()) return false;
+  if (linkPropertyTypeIsLand(low) || linkPropertyTypeIsCommercial(low)) return false;
+  return (
+    /\b(single.?family|1.?family|one.?family|sfr|detached|attached)\b/i.test(low) ||
+    /\b(condo|townhouse|town house|co-?op|cooperative)\b/i.test(low) ||
+    /\baffordable\b/i.test(low) ||
+    /\b(guest|carriage|in-?law|accessory)\b/i.test(low) ||
+    /\b(multi|duplex|triplex|2-?4 units|investment)\b/i.test(low) ||
+    (/\bresidential\b/i.test(low) && !/\bland\b/i.test(low))
+  );
 }
 
 export function linkMatchesPropertyTypes(propertyType: string | null, keys: LinkPropertyTypeKey[]): boolean {
   if (!keys.length) return true;
-  const s = (propertyType ?? "").toLowerCase();
-  if (!s.trim()) return false;
+  const raw = propertyType ?? "";
+  if (!raw.trim()) return false;
+  const low = raw.toLowerCase();
   return keys.some((k) => {
     switch (k) {
-      case "sf":
-        return /\b(single.?family|sfr|detached)\b/i.test(s) || (s.includes("residential") && !s.includes("condo"));
-      case "condo":
-        return /\b(condo|townhouse|town house|attached)\b/i.test(s);
       case "land":
-        return /\b(land|lot|lots|acre|unimproved|vacant land)\b/i.test(s);
-      case "guest":
-        return /\b(guest|carriage|in-?law|accessory)\b/i.test(s);
-      case "multi":
-        return /\b(multi|duplex|triplex|2.?4 units|investment)\b/i.test(s);
+        return linkPropertyTypeIsLand(low);
+      case "commercial":
+        return linkPropertyTypeIsCommercial(low);
+      case "houses":
+        return linkPropertyTypeIsHouses(low);
       default:
         return false;
     }
@@ -203,7 +198,6 @@ export function countActiveLinkFilters(f: LinkFiltersState): number {
   if (f.waterfront) n += 1;
   if (f.walkToTown) n += 1;
   if (f.renoRecent) n += 1;
-  if (f.highYieldZones) n += 1;
   if (f.propertyTypes.length) n += 1;
   if (f.soldCloseAfter.trim() || f.soldCloseBefore.trim()) n += 1;
   if (f.minDom.trim() || f.maxDom.trim()) n += 1;
@@ -305,7 +299,6 @@ export function filterLinkFeatureCollection(
     if (f.waterfront && !wf) return false;
     if (f.walkToTown && !p.townWalkHint) return false;
     if (f.renoRecent && !p.renoHint) return false;
-    if (f.highYieldZones && !isHighYieldMlsArea(p.mlsArea)) return false;
     if (!linkMatchesPropertyTypes(p.propertyType, f.propertyTypes)) return false;
 
     if (maxPpsf != null) {

--- a/src/lib/schedule-call-url.ts
+++ b/src/lib/schedule-call-url.ts
@@ -1,2 +1,2 @@
-/** Google Calendar scheduling — used for “Schedule a Call” / book time with Stephen. */
+/** Google Calendar scheduling — default “Schedule a Call” CTA; property map may override for vacation rentals. */
 export const SCHEDULE_CALL_URL = "https://calendar.app.google/e6pvoyZwp3Fe64gv5";

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/warm-map-rentals",
+      "schedule": "*/10 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR combines **cached NR map inventory** (prior commit) with **property map UI and behavior updates** (latest commit).

### Performance / data
- `/api/map/rentals` inventory caching + optional cron warm (existing commit on branch).

### Filters and MLS (LINK) sheet
- Property type: **Houses** (1-family, condo, affordable, co-op, etc.), **Land**, **Commercial** with matching logic in `property-map-filters.ts`.
- Tabs: **Vacation Rentals** / For sale / Sold when multiple modes are on.
- **MLS Listings** section label; removed save/alerts, custom price, $/sqft, high-yield zones, and Advanced drawer (DOM + sold dates in main body).
- Map mode chips: **all modes can be deselected**; URL uses `mode=none`; filters sheet handles empty selection.

### Map overlay
- Single **Overlay** chip (popover): MLS Areas, Zoning, **None** (neutral parcels); `parcelBaseLayer` includes `none` in `ZoningMap`.

### Intelligence panel / hero
- MLS pill: **For Sale | N days on market** (and sold variant); parcel API match includes `onMarketDate` / `closeDate` for DOM when viewing by parcel.
- Slide-up: **Check Availability** for vacation-rental selection; hide watch heart and legal links in compact drawer footer.

### Other
- Disclaimer page: drop boilerplate placeholder paragraph.

## Test plan
- [ ] Property map: toggle all listing-type chips off and on; URL `mode=` updates; pins and filters sheet behave as expected.
- [ ] Overlay chip: MLS Areas / Zoning / None and map styling.
- [ ] MLS active listing: hero pill shows DOM; sold shows sold DOM when dates exist.
- [ ] Mobile drawer: no heart; no Privacy/Terms/Disclaimer; rental CTA label when a rental pin is selected.
- [ ] `/api/map/rentals` + cron warm still behave as before (if deployed).