### PR TITLE
Property map: MLS overlay, filters, sold chips, and map polish

### DIFF
--- a/src/app/api/map/link-listings/route.ts
+++ b/src/app/api/map/link-listings/route.ts
@@ -12,6 +12,7 @@ import {
   type LinkListingRow,
   type ParcelProps,
 } from "@/lib/link-listings-parcel-match";
+import { LINK_MAP_DEFAULT_SOLD_FEED_DAYS } from "@/lib/property-map-filters";
 
 const GEOJSON_PATH = path.join(process.cwd(), "src/data/zoning-tool/nantucket-tax-parcels.clean.geojson");
 
@@ -29,7 +30,7 @@ function loadParcelFeatures(): Feature<Geometry, ParcelProps>[] {
 }
 
 /**
- * GET /api/map/link-listings?bbox=west,south,east,north&pool=active|sold|both&soldDays=1095
+ * GET /api/map/link-listings?bbox=west,south,east,north&pool=active|sold|both&soldDays=…
  *
  * Active and sold LINK (C&C) listings placed on parcel centroids by normalized street address.
  */
@@ -38,7 +39,10 @@ export async function GET(request: Request) {
   const parcelIdParam = searchParams.get("parcel_id")?.trim() ?? "";
   const bboxRaw = searchParams.get("bbox");
   const pool = (searchParams.get("pool") ?? "both").toLowerCase();
-  const soldDays = Math.min(Math.max(parseInt(searchParams.get("soldDays") ?? "1095", 10), 30), 3650);
+  const soldDays = Math.min(
+    Math.max(parseInt(searchParams.get("soldDays") ?? String(LINK_MAP_DEFAULT_SOLD_FEED_DAYS), 10), 30),
+    3650,
+  );
 
   if (parcelIdParam) {
     if (!["active", "sold", "both"].includes(pool)) {

--- a/src/components/map/PropertyMapFiltersSheet.tsx
+++ b/src/components/map/PropertyMapFiltersSheet.tsx
@@ -18,7 +18,9 @@ import {
   countActiveRentalFilters,
   DEFAULT_LINK_FILTERS,
   DEFAULT_RENTAL_FILTERS,
+  LINK_FILTERS_SOLD_IN_LAST_OPTIONS,
   LINK_PROPERTY_TYPE_LABELS,
+  type LinkFiltersSoldInLast,
   type LinkFiltersState,
   type LinkPropertyTypeKey,
   type PropertyMapMode,
@@ -130,11 +132,12 @@ export function PropertyMapFiltersSheet({
   const showLink = showSale || showSold;
   const showSoldTools = showSold;
 
+  /** Tabs left → right: For sale, Sold, then Vacation Rentals (rent). */
   const tabIds = useMemo((): FilterSheetTab[] => {
     const ids: FilterSheetTab[] = [];
-    if (showRent) ids.push("rent");
     if (showSale) ids.push("sale");
     if (showSold) ids.push("sold");
+    if (showRent) ids.push("rent");
     return ids;
   }, [showRent, showSale, showSold]);
 
@@ -144,6 +147,10 @@ export function PropertyMapFiltersSheet({
     if (tabIds.length === 0) return;
     if (!tabIds.includes(activeTab)) setActiveTab(tabIds[0]!);
   }, [tabIds, activeTab]);
+
+  /** Sold date UI only on Sold tab (or single-mode sold). */
+  const showSoldDateControls = showSoldTools && (tabIds.length === 1 || activeTab === "sold");
+  const showDomControls = activeTab !== "sold";
 
   const rentBadge = showRent ? countActiveRentalFilters(rentalFilters) : 0;
   const linkBadge = showLink ? countActiveLinkFilters(linkFilters) : 0;
@@ -156,7 +163,7 @@ export function PropertyMapFiltersSheet({
 
   const headline = useMemo(() => {
     if (!showRent && !showSale && !showSold) {
-      return "No listing types selected — turn on For rent, For sale, and/or Sold above";
+      return "No listing types selected — turn on For sale, Sold, and/or Vacation Rentals above";
     }
     const parts: string[] = [];
     if (showRent && !showLink) {
@@ -209,15 +216,15 @@ export function PropertyMapFiltersSheet({
         <SheetContent
           side={side}
           className={cn(
-            "flex max-h-[90dvh] flex-col gap-0 overflow-hidden bg-white p-0 shadow-2xl",
+            "flex max-h-[90dvh] w-full max-w-[100vw] flex-col gap-0 overflow-x-hidden overflow-y-hidden bg-white p-0 shadow-2xl",
             side === "top"
               ? "rounded-b-2xl border-b-2 border-blue-700/35"
               : "rounded-t-2xl border-t-2 border-blue-700/35",
           )}
         >
           <SheetHeader className="shrink-0 space-y-2 border-b border-[var(--cedar-shingle)]/15 px-4 pb-3 pt-4 text-left">
-            <div className="flex items-start justify-between gap-3 pr-10">
-              <div>
+            <div className="flex min-w-0 items-start justify-between gap-3 pr-10">
+              <div className="min-w-0 flex-1">
                 <SheetTitle className="text-lg text-[var(--atlantic-navy)]">Map filters</SheetTitle>
                 <p className="mt-1 text-xs leading-snug text-[var(--nantucket-gray)]">
                   <span className="font-semibold text-blue-800">{headline}</span>
@@ -239,7 +246,7 @@ export function PropertyMapFiltersSheet({
             <div
               role="tablist"
               aria-label="Listing type filters"
-              className="flex shrink-0 gap-0 border-b border-[var(--cedar-shingle)]/15 px-2"
+              className="flex min-w-0 shrink-0 gap-0 border-b border-[var(--cedar-shingle)]/15 px-2"
             >
               {tabIds.map((id) => {
                 const selectedTab = activeTab === id;
@@ -254,14 +261,14 @@ export function PropertyMapFiltersSheet({
                     aria-selected={selectedTab}
                     onClick={() => setActiveTab(id)}
                     className={cn(
-                      "relative min-h-11 flex-1 px-2 py-2.5 text-center text-xs font-semibold transition-colors",
+                      "relative min-h-11 min-w-0 flex-1 px-1.5 py-2.5 text-center text-[11px] font-semibold leading-tight transition-colors sm:px-2 sm:text-xs",
                       selectedTab
                         ? "text-blue-800 after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-blue-700"
                         : "text-[var(--nantucket-gray)] hover:text-[var(--atlantic-navy)]",
                     )}
                   >
-                    <span className="inline-flex flex-col items-center gap-0.5">
-                      <span>{label}</span>
+                    <span className="inline-flex max-w-full flex-col items-center gap-0.5">
+                      <span className="line-clamp-2 break-words">{label}</span>
                       {tabBadge > 0 ? (
                         <span className="rounded-full bg-blue-700 px-1.5 py-px text-[10px] font-bold leading-none text-white">
                           {tabBadge > 99 ? "99+" : tabBadge}
@@ -274,7 +281,7 @@ export function PropertyMapFiltersSheet({
             </div>
           ) : null}
 
-          <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 py-4">
+          <div className="min-h-0 min-w-0 flex-1 space-y-6 overflow-y-auto overflow-x-hidden px-4 py-4">
             {tabIds.length === 0 ? (
               <p className="rounded-md border border-[var(--cedar-shingle)]/20 bg-[var(--sandstone)]/40 px-3 py-2 text-xs leading-snug text-[var(--atlantic-navy)]">
                 Select at least one listing type using the chips on the map toolbar to filter pins here.
@@ -374,20 +381,9 @@ export function PropertyMapFiltersSheet({
 
             {viewingLink ? (
               <section className="space-y-4">
-                {tabIds.length > 1 && (activeTab === "sale" || activeTab === "sold") ? (
-                  <p className="rounded-md border border-blue-700/10 bg-blue-50/60 px-2.5 py-1.5 text-[11px] leading-snug text-blue-950">
-                    {activeTab === "sale"
-                      ? showSold
-                        ? "Active MLS pins: criteria below also shape sold pins where the same field applies (e.g. price, beds). Sold close dates can be filtered below when sold pins are on."
-                        : "Criteria below apply to active MLS pins in the current map view."
-                      : showSale
-                        ? "Sold MLS pins: criteria below also shape active pins where the same field applies. Sold close dates are below."
-                        : "Criteria below apply to sold MLS pins in the current map view."}
-                  </p>
-                ) : null}
-                <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center justify-between gap-2">
                   <SectionLabel>MLS Listings</SectionLabel>
-                  <span className="text-right text-[11px] font-medium leading-tight text-blue-900">
+                  <span className="min-w-0 shrink text-right text-[11px] font-medium leading-tight text-blue-900">
                     {showSale ? (
                       <span>
                         {pinSummary.linkActiveFiltered}/{pinSummary.linkActiveTotal} active
@@ -401,6 +397,32 @@ export function PropertyMapFiltersSheet({
                     ) : null}
                   </span>
                 </div>
+
+                {showSoldDateControls ? (
+                  <label className="block min-w-0">
+                    <span className="mb-1 block text-[11px] font-medium text-[var(--atlantic-navy)]">Sold in last:</span>
+                    <select
+                      value={linkFilters.soldInLast}
+                      onChange={(e) =>
+                        onLinkFiltersChange({
+                          ...linkFilters,
+                          soldInLast: e.target.value as LinkFiltersSoldInLast,
+                        })
+                      }
+                      className="h-10 w-full min-w-0 max-w-full rounded-lg border border-[var(--cedar-shingle)]/25 bg-white px-3 text-sm text-[var(--atlantic-navy)] shadow-sm"
+                    >
+                      <option value="" hidden>
+                        &#8203;
+                      </option>
+                      {LINK_FILTERS_SOLD_IN_LAST_OPTIONS.map(({ value, label }) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+
                 <div>
                   <p className="mb-1.5 text-[11px] font-medium text-[var(--atlantic-navy)]">Property type</p>
                   <div className="flex flex-wrap gap-1.5">
@@ -512,10 +534,10 @@ export function PropertyMapFiltersSheet({
                   </label>
                   <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-xs font-medium text-[var(--atlantic-navy)] has-[:checked]:border-blue-700/30 has-[:checked]:bg-white">
                     <Checkbox
-                      checked={linkFilters.walkToTown}
-                      onCheckedChange={(v) => onLinkFiltersChange({ ...linkFilters, walkToTown: v === true })}
+                      checked={linkFilters.pool}
+                      onCheckedChange={(v) => onLinkFiltersChange({ ...linkFilters, pool: v === true })}
                     />
-                    Walk to Town
+                    Pool
                   </label>
                   <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-xs font-medium text-[var(--atlantic-navy)] has-[:checked]:border-blue-700/30 has-[:checked]:bg-white">
                     <Checkbox
@@ -524,60 +546,32 @@ export function PropertyMapFiltersSheet({
                     />
                     New construction
                   </label>
-                  <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-xs font-medium text-[var(--atlantic-navy)] has-[:checked]:border-blue-700/30 has-[:checked]:bg-white">
-                    <Checkbox
-                      checked={linkFilters.renoRecent}
-                      onCheckedChange={(v) => onLinkFiltersChange({ ...linkFilters, renoRecent: v === true })}
-                    />
-                    Recently renovated
-                  </label>
                 </div>
 
-                {showSoldTools ? (
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <div>
-                      <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Sold — closed after</p>
+                {showDomControls ? (
+                  <div className="grid min-w-0 max-w-full grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div className="min-w-0">
+                      <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (min)</p>
                       <Input
-                        type="date"
-                        value={linkFilters.soldCloseAfter}
-                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, soldCloseAfter: e.target.value })}
-                        className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
+                        inputMode="numeric"
+                        placeholder="Any"
+                        value={linkFilters.minDom}
+                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, minDom: e.target.value })}
+                        className="h-10 w-full min-w-0 max-w-full rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
                       />
                     </div>
-                    <div>
-                      <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Sold — closed before</p>
+                    <div className="min-w-0">
+                      <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (max)</p>
                       <Input
-                        type="date"
-                        value={linkFilters.soldCloseBefore}
-                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, soldCloseBefore: e.target.value })}
-                        className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
+                        inputMode="numeric"
+                        placeholder="Any"
+                        value={linkFilters.maxDom}
+                        onChange={(e) => onLinkFiltersChange({ ...linkFilters, maxDom: e.target.value })}
+                        className="h-10 w-full min-w-0 max-w-full rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
                       />
                     </div>
                   </div>
                 ) : null}
-
-                <div className="grid grid-cols-2 gap-2">
-                  <div>
-                    <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (min)</p>
-                    <Input
-                      inputMode="numeric"
-                      placeholder="Any"
-                      value={linkFilters.minDom}
-                      onChange={(e) => onLinkFiltersChange({ ...linkFilters, minDom: e.target.value })}
-                      className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
-                    />
-                  </div>
-                  <div>
-                    <p className="mb-1 text-[11px] font-medium text-[var(--atlantic-navy)]">Days on market (max)</p>
-                    <Input
-                      inputMode="numeric"
-                      placeholder="Any"
-                      value={linkFilters.maxDom}
-                      onChange={(e) => onLinkFiltersChange({ ...linkFilters, maxDom: e.target.value })}
-                      className="h-10 rounded-lg border-[var(--cedar-shingle)]/25 text-sm"
-                    />
-                  </div>
-                </div>
               </section>
             ) : null}
           </div>

--- a/src/components/map/PropertyMapLayerBar.tsx
+++ b/src/components/map/PropertyMapLayerBar.tsx
@@ -123,16 +123,16 @@ export function PropertyMapOverlayChip({
   const [open, setOpen] = useState(false);
   const currentLabel = overlayOptionLabel(parcelBaseLayer);
   const isMlsAreas = parcelBaseLayer === "re_market_areas";
-  const buttonCaption = isMlsAreas ? "Overlay" : `Overlay: ${currentLabel}`;
 
   return (
-    <div className={cn("flex min-w-0 flex-wrap items-center gap-1.5", className)}>
+    <div className={cn(className)}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <button
             type="button"
             className={cn(
               "inline-flex shrink-0 items-center gap-1 rounded-full border border-[var(--cedar-shingle)]/35 bg-white/95 px-2.5 py-0.5 text-[11px] font-semibold normal-case text-[var(--atlantic-navy)] shadow-sm transition-colors hover:border-[var(--cedar-shingle)]/55 hover:bg-[var(--sandstone)]/90",
+              isMlsAreas && "border-blue-700/30 bg-blue-50/95 hover:border-blue-700/45 hover:bg-blue-50",
               layout === "stack" && "w-full justify-center",
               triggerClassName,
             )}
@@ -140,7 +140,18 @@ export function PropertyMapOverlayChip({
             aria-expanded={open}
             aria-label={`Map overlay: ${currentLabel}. Change overlay.`}
           >
-            <span className="max-w-[11rem] truncate sm:max-w-[14rem]">{buttonCaption}</span>
+            {isMlsAreas ? (
+              <span className="flex min-w-0 max-w-[min(100vw-8rem,18rem)] items-center gap-1.5 truncate">
+                <span className="shrink-0 text-[10px] font-bold uppercase tracking-wide text-[var(--nantucket-gray)]">
+                  Overlay
+                </span>
+                <span className="min-w-0 truncate text-[11px] font-semibold text-blue-900" title="Neighborhood-style MLS district polygons">
+                  MLS Areas
+                </span>
+              </span>
+            ) : (
+              <span className="max-w-[11rem] truncate sm:max-w-[14rem]">Overlay: {currentLabel}</span>
+            )}
             <ChevronDown
               className={cn("h-3.5 w-3.5 shrink-0 opacity-70 transition-transform", open && "rotate-180")}
               aria-hidden
@@ -177,14 +188,6 @@ export function PropertyMapOverlayChip({
           </div>
         </PopoverContent>
       </Popover>
-      {isMlsAreas ? (
-        <span
-          className="shrink-0 text-[11px] font-semibold leading-tight tracking-tight text-blue-900"
-          title="Neighborhood-style MLS district polygons"
-        >
-          MLS Areas
-        </span>
-      ) : null}
     </div>
   );
 }

--- a/src/components/map/PropertyMapLayerBar.tsx
+++ b/src/components/map/PropertyMapLayerBar.tsx
@@ -88,6 +88,8 @@ type LayerPillsProps = {
   onParcelBaseLayer: (v: ParcelBaseMapLayer) => void;
   onOpenFilters: () => void;
   filterBadgeCount: number;
+  /** When false, hide the Filters control (e.g. no listing-type chip selected). */
+  showFiltersButton?: boolean;
 };
 
 const OVERLAY_OPTIONS = [
@@ -187,30 +189,38 @@ export function PropertyMapLayerPillsRow({
   onParcelBaseLayer,
   onOpenFilters,
   filterBadgeCount,
+  showFiltersButton = true,
 }: LayerPillsProps) {
   const filtersActive = filterBadgeCount > 0;
   const filtersIconClass = filtersActive ? "text-white" : "text-[var(--cedar-shingle)]";
 
   return (
-    <div className={cn("flex gap-1.5", layout === "stack" ? "flex-col items-stretch" : "flex-row flex-wrap items-center")}>
+    <div
+      className={cn(
+        "flex min-w-0 gap-1.5",
+        layout === "stack" ? "flex-col items-stretch" : "flex-row flex-wrap items-center",
+      )}
+    >
       <PropertyMapOverlayChip parcelBaseLayer={parcelBaseLayer} onParcelBaseLayer={onParcelBaseLayer} layout={layout} />
-      <button
-        type="button"
-        onClick={onOpenFilters}
-        className={cn(
-          filtersActive ? layerPillActiveSolid() : layerPillInactive(),
-          "gap-1",
-          layout === "stack" && "justify-center",
-        )}
-      >
-        <SlidersHorizontal className={cn("h-3.5 w-3.5 shrink-0 stroke-[2]", filtersIconClass)} aria-hidden />
-        Filters
-        {filterBadgeCount > 0 ? (
-          <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-white/25 px-1 text-[9px] font-bold text-white">
-            {filterBadgeCount > 99 ? "99+" : filterBadgeCount}
-          </span>
-        ) : null}
-      </button>
+      {showFiltersButton ? (
+        <button
+          type="button"
+          onClick={onOpenFilters}
+          className={cn(
+            filtersActive ? layerPillActiveSolid() : layerPillInactive(),
+            "gap-1",
+            layout === "stack" && "justify-center",
+          )}
+        >
+          <SlidersHorizontal className={cn("h-3.5 w-3.5 shrink-0 stroke-[2]", filtersIconClass)} aria-hidden />
+          Filters
+          {filterBadgeCount > 0 ? (
+            <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-white/25 px-1 text-[9px] font-bold text-white">
+              {filterBadgeCount > 99 ? "99+" : filterBadgeCount}
+            </span>
+          ) : null}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -252,6 +262,7 @@ type DesktopBarProps = {
   onRequestFlyToReDistrict: (abbrv: string) => void;
   onOpenFilters: () => void;
   filterBadgeCount: number;
+  showFiltersButton?: boolean;
 };
 
 export function PropertyMapDesktopLayerBar({
@@ -264,6 +275,7 @@ export function PropertyMapDesktopLayerBar({
   onRequestFlyToReDistrict,
   onOpenFilters,
   filterBadgeCount,
+  showFiltersButton = true,
 }: DesktopBarProps) {
   const showFocus = parcelBaseLayer === "re_market_areas";
 
@@ -277,6 +289,7 @@ export function PropertyMapDesktopLayerBar({
           onParcelBaseLayer={onParcelBaseLayer}
           onOpenFilters={onOpenFilters}
           filterBadgeCount={filterBadgeCount}
+          showFiltersButton={showFiltersButton}
         />
         <PropertyMapLayerHelpTrigger />
       </div>
@@ -301,6 +314,7 @@ type SheetBodyProps = {
   onRequestFlyToReDistrict: (abbrv: string) => void;
   onOpenFilters: () => void;
   filterBadgeCount: number;
+  showFiltersButton?: boolean;
 };
 
 export function PropertyMapLayersSheetBody({
@@ -313,6 +327,7 @@ export function PropertyMapLayersSheetBody({
   onRequestFlyToReDistrict,
   onOpenFilters,
   filterBadgeCount,
+  showFiltersButton = true,
 }: SheetBodyProps) {
   const showFocus = parcelBaseLayer === "re_market_areas";
 
@@ -331,6 +346,7 @@ export function PropertyMapLayersSheetBody({
           onParcelBaseLayer={onParcelBaseLayer}
           onOpenFilters={onOpenFilters}
           filterBadgeCount={filterBadgeCount}
+          showFiltersButton={showFiltersButton}
         />
       </div>
       {showFocus ? (

--- a/src/components/map/PropertyMapLayerBar.tsx
+++ b/src/components/map/PropertyMapLayerBar.tsx
@@ -122,9 +122,11 @@ export function PropertyMapOverlayChip({
 }: OverlayChipProps) {
   const [open, setOpen] = useState(false);
   const currentLabel = overlayOptionLabel(parcelBaseLayer);
+  const isMlsAreas = parcelBaseLayer === "re_market_areas";
+  const buttonCaption = isMlsAreas ? "Overlay" : `Overlay: ${currentLabel}`;
 
   return (
-    <div className={cn(className)}>
+    <div className={cn("flex min-w-0 flex-wrap items-center gap-1.5", className)}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <button
@@ -138,9 +140,7 @@ export function PropertyMapOverlayChip({
             aria-expanded={open}
             aria-label={`Map overlay: ${currentLabel}. Change overlay.`}
           >
-            <span className="max-w-[11rem] truncate sm:max-w-[14rem]">
-              Overlay: {currentLabel}
-            </span>
+            <span className="max-w-[11rem] truncate sm:max-w-[14rem]">{buttonCaption}</span>
             <ChevronDown
               className={cn("h-3.5 w-3.5 shrink-0 opacity-70 transition-transform", open && "rotate-180")}
               aria-hidden
@@ -177,6 +177,14 @@ export function PropertyMapOverlayChip({
           </div>
         </PopoverContent>
       </Popover>
+      {isMlsAreas ? (
+        <span
+          className="shrink-0 text-[11px] font-semibold leading-tight tracking-tight text-blue-900"
+          title="Neighborhood-style MLS district polygons"
+        >
+          MLS Areas
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/components/zoning/ZoningLookupClient.tsx
+++ b/src/components/zoning/ZoningLookupClient.tsx
@@ -45,6 +45,7 @@ import {
   DEFAULT_LINK_FILTERS,
   DEFAULT_RENTAL_FILTERS,
   filterLinkFeatureCollection,
+  LINK_MAP_DEFAULT_SOLD_FEED_DAYS,
   removeMapAppliedFilterChip,
   type LinkFiltersState,
   type PropertyMapMode,
@@ -604,7 +605,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
     const pool = hasSaleMode && hasSoldMode ? "both" : hasSaleMode ? "active" : "sold";
     const ac = new AbortController();
     fetch(
-      `/api/map/link-listings?parcel_id=${encodeURIComponent(pid)}&pool=${encodeURIComponent(pool)}&soldDays=1095`,
+      `/api/map/link-listings?parcel_id=${encodeURIComponent(pid)}&pool=${encodeURIComponent(pool)}&soldDays=${LINK_MAP_DEFAULT_SOLD_FEED_DAYS}`,
       { signal: ac.signal },
     )
       .then(async (r) => {
@@ -1398,42 +1399,58 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   role="list"
                   aria-label="Active map filters"
                 >
-                  {appliedFilterChips.map((chip) => (
-                    <button
-                      key={chip.id}
-                      type="button"
-                      role="listitem"
-                      aria-label={`Remove filter: ${chip.label}`}
-                      className={cn(
-                        "inline-flex max-w-full items-center gap-1 rounded-full border py-0.5 pl-2.5 pr-1 text-[11px] font-medium leading-tight shadow-sm transition-colors",
-                        chip.source === "rental"
-                          ? "border-emerald-700/25 bg-emerald-50/95 text-emerald-950 hover:border-emerald-700/40 hover:bg-emerald-50"
-                          : "border-blue-700/25 bg-blue-50/95 text-blue-950 hover:border-blue-700/40 hover:bg-blue-50",
-                      )}
-                      onClick={() => {
-                        const { rental: nextR, link: nextL } = removeMapAppliedFilterChip(
-                          chip.id,
-                          rentalFilters,
-                          linkFilters,
-                        );
-                        setRentalFilters(nextR);
-                        setLinkFilters(nextL);
-                      }}
-                    >
-                      <span className="min-w-0 truncate">{chip.label}</span>
+                  {appliedFilterChips.map((chip) =>
+                    chip.dismissable === false ? (
                       <span
+                        key={chip.id}
+                        role="listitem"
+                        title="Sold pins use the map feed lookback. Open Filters to narrow by a shorter window."
                         className={cn(
-                          "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold",
+                          "inline-flex max-w-full items-center rounded-full border py-0.5 pl-2.5 pr-2.5 text-[11px] font-medium leading-tight text-blue-950 shadow-sm",
                           chip.source === "rental"
-                            ? "bg-emerald-700/15 text-emerald-900 hover:bg-emerald-700/25"
-                            : "bg-blue-700/15 text-blue-900 hover:bg-blue-700/25",
+                            ? "border-emerald-700/25 bg-emerald-50/95"
+                            : "border-blue-700/25 bg-blue-50/95",
                         )}
-                        aria-hidden
                       >
-                        <X className="h-3 w-3" strokeWidth={2.5} />
+                        <span className="min-w-0 truncate">{chip.label}</span>
                       </span>
-                    </button>
-                  ))}
+                    ) : (
+                      <button
+                        key={chip.id}
+                        type="button"
+                        role="listitem"
+                        aria-label={`Remove filter: ${chip.label}`}
+                        className={cn(
+                          "inline-flex max-w-full items-center gap-1 rounded-full border py-0.5 pl-2.5 pr-1 text-[11px] font-medium leading-tight shadow-sm transition-colors",
+                          chip.source === "rental"
+                            ? "border-emerald-700/25 bg-emerald-50/95 text-emerald-950 hover:border-emerald-700/40 hover:bg-emerald-50"
+                            : "border-blue-700/25 bg-blue-50/95 text-blue-950 hover:border-blue-700/40 hover:bg-blue-50",
+                        )}
+                        onClick={() => {
+                          const { rental: nextR, link: nextL } = removeMapAppliedFilterChip(
+                            chip.id,
+                            rentalFilters,
+                            linkFilters,
+                          );
+                          setRentalFilters(nextR);
+                          setLinkFilters(nextL);
+                        }}
+                      >
+                        <span className="min-w-0 truncate">{chip.label}</span>
+                        <span
+                          className={cn(
+                            "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold",
+                            chip.source === "rental"
+                              ? "bg-emerald-700/15 text-emerald-900 hover:bg-emerald-700/25"
+                              : "bg-blue-700/15 text-blue-900 hover:bg-blue-700/25",
+                          )}
+                          aria-hidden
+                        >
+                          <X className="h-3 w-3" strokeWidth={2.5} />
+                        </span>
+                      </button>
+                    ),
+                  )}
                 </div>
               ) : null}
 

--- a/src/components/zoning/ZoningLookupClient.tsx
+++ b/src/components/zoning/ZoningLookupClient.tsx
@@ -199,6 +199,7 @@ function linkPinFromOmniboxHit(hit: OmniboxActiveListing | OmniboxSoldComp, pool
     livingAreaSqft: null,
     renoHint: false,
     townWalkHint: false,
+    hasPool: false,
     longitude: hit.lng ?? null,
     latitude: hit.lat ?? null,
   };
@@ -461,7 +462,12 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
   const hasRentMode = mapModes.includes("rent");
   const hasSaleMode = mapModes.includes("sale");
   const hasSoldMode = mapModes.includes("sold");
+  const hasListingTypeSelected = mapModes.length > 0;
   const mapModeForOmnibox = effectiveModeForOmnibox(mapModes);
+
+  useEffect(() => {
+    if (mapModes.length === 0) setFiltersOpen(false);
+  }, [mapModes.length]);
 
   const mapResearchHubPrimaryCta = useMemo(() => {
     if (!selectedRental) return null;
@@ -1309,8 +1315,8 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   {(
                     [
                       { mode: "sale" as const, label: "For sale" },
-                      { mode: "rent" as const, label: "For rent" },
                       { mode: "sold" as const, label: "Sold" },
+                      { mode: "rent" as const, label: "Vacation Rentals" },
                     ] as const
                   ).map(({ mode, label }) => (
                     <button
@@ -1353,20 +1359,22 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   parcelBaseLayer={parcelBaseLayer}
                   onParcelBaseLayer={applyParcelBaseLayer}
                 />
-                <button
-                  type="button"
-                  onClick={() => setFiltersOpen(true)}
-                  className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[var(--cedar-shingle)]/30 bg-white px-2 py-0.5 text-[11px] font-medium text-[var(--atlantic-navy)] transition-colors hover:bg-[var(--sandstone)] lg:hidden"
-                  aria-label="Open filters"
-                >
-                  Filters
-                  <ChevronDown className="h-3.5 w-3.5 text-[var(--nantucket-gray)]" aria-hidden />
-                  {filterBadgeCount > 0 ? (
-                    <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-700 px-1 text-[9px] font-semibold text-white">
-                      {filterBadgeCount > 99 ? "99+" : filterBadgeCount}
-                    </span>
-                  ) : null}
-                </button>
+                {hasListingTypeSelected ? (
+                  <button
+                    type="button"
+                    onClick={() => setFiltersOpen(true)}
+                    className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[var(--cedar-shingle)]/30 bg-white px-2 py-0.5 text-[11px] font-medium text-[var(--atlantic-navy)] transition-colors hover:bg-[var(--sandstone)] lg:hidden"
+                    aria-label="Open filters"
+                  >
+                    Filters
+                    <ChevronDown className="h-3.5 w-3.5 text-[var(--nantucket-gray)]" aria-hidden />
+                    {filterBadgeCount > 0 ? (
+                      <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-700 px-1 text-[9px] font-semibold text-white">
+                        {filterBadgeCount > 99 ? "99+" : filterBadgeCount}
+                      </span>
+                    ) : null}
+                  </button>
+                ) : null}
               </div>
               <div className="hidden min-w-0 lg:block">
                 <PropertyMapDesktopLayerBar
@@ -1383,6 +1391,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   }}
                   onOpenFilters={() => setFiltersOpen(true)}
                   filterBadgeCount={filterBadgeCount}
+                  showFiltersButton={hasListingTypeSelected}
                 />
               </div>
             </div>
@@ -1559,7 +1568,7 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   <div className={cn(mapUiHidden && "pointer-events-none opacity-0")}>
                     <PropertyMapFiltersSheet
                       trigger="none"
-                      open={filtersOpen}
+                      open={filtersOpen && hasListingTypeSelected}
                       onOpenChange={setFiltersOpen}
                       side={isPropertyMap && layoutNarrow ? "top" : "bottom"}
                       mapMode={mapModeForOmnibox}

--- a/src/components/zoning/ZoningLookupClient.tsx
+++ b/src/components/zoning/ZoningLookupClient.tsx
@@ -39,11 +39,13 @@ import {
 } from "@/lib/nr-vacation-rental-url";
 import {
   applyRentalFilters,
+  buildMapAppliedFilterChips,
   countActiveLinkFilters,
   countActiveRentalFilters,
   DEFAULT_LINK_FILTERS,
   DEFAULT_RENTAL_FILTERS,
   filterLinkFeatureCollection,
+  removeMapAppliedFilterChip,
   type LinkFiltersState,
   type PropertyMapMode,
   type RentalFiltersState,
@@ -486,7 +488,8 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
     setSelectedRental(null);
     setSelectedLink(null);
     setRentalFilters({ ...DEFAULT_RENTAL_FILTERS });
-    setLinkFilters({ ...DEFAULT_LINK_FILTERS });
+    const soldInLastDefault = mapModes.includes("sold") ? ("30d" as const) : ("" as const);
+    setLinkFilters({ ...DEFAULT_LINK_FILTERS, soldInLast: soldInLastDefault });
   }, [mapModes]);
 
   const setMapModesAndUrl = useCallback(
@@ -666,6 +669,18 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
     const showLink = hasSaleMode || hasSoldMode;
     return (showRent ? countActiveRentalFilters(rentalFilters) : 0) + (showLink ? countActiveLinkFilters(linkFilters) : 0);
   }, [hasRentMode, hasSaleMode, hasSoldMode, rentalFilters, linkFilters]);
+
+  const appliedFilterChips = useMemo(
+    () =>
+      buildMapAppliedFilterChips({
+        rental: rentalFilters,
+        link: linkFilters,
+        showRent: hasRentMode,
+        showLink: hasSaleMode || hasSoldMode,
+        showSold: hasSoldMode,
+      }),
+    [rentalFilters, linkFilters, hasRentMode, hasSaleMode, hasSoldMode],
+  );
 
   useEffect(() => {
     if (!selectedRental) return;
@@ -1376,6 +1391,52 @@ export function ZoningLookupClient({ variant = "tool" }: { variant?: ZoningLooku
                   </button>
                 ) : null}
               </div>
+
+              {hasListingTypeSelected && appliedFilterChips.length > 0 ? (
+                <div
+                  className="flex min-w-0 flex-wrap items-center gap-1.5 border-t border-[var(--cedar-shingle)]/10 pt-1.5 sm:pt-2"
+                  role="list"
+                  aria-label="Active map filters"
+                >
+                  {appliedFilterChips.map((chip) => (
+                    <button
+                      key={chip.id}
+                      type="button"
+                      role="listitem"
+                      aria-label={`Remove filter: ${chip.label}`}
+                      className={cn(
+                        "inline-flex max-w-full items-center gap-1 rounded-full border py-0.5 pl-2.5 pr-1 text-[11px] font-medium leading-tight shadow-sm transition-colors",
+                        chip.source === "rental"
+                          ? "border-emerald-700/25 bg-emerald-50/95 text-emerald-950 hover:border-emerald-700/40 hover:bg-emerald-50"
+                          : "border-blue-700/25 bg-blue-50/95 text-blue-950 hover:border-blue-700/40 hover:bg-blue-50",
+                      )}
+                      onClick={() => {
+                        const { rental: nextR, link: nextL } = removeMapAppliedFilterChip(
+                          chip.id,
+                          rentalFilters,
+                          linkFilters,
+                        );
+                        setRentalFilters(nextR);
+                        setLinkFilters(nextL);
+                      }}
+                    >
+                      <span className="min-w-0 truncate">{chip.label}</span>
+                      <span
+                        className={cn(
+                          "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold",
+                          chip.source === "rental"
+                            ? "bg-emerald-700/15 text-emerald-900 hover:bg-emerald-700/25"
+                            : "bg-blue-700/15 text-blue-900 hover:bg-blue-700/25",
+                        )}
+                        aria-hidden
+                      >
+                        <X className="h-3 w-3" strokeWidth={2.5} />
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
               <div className="hidden min-w-0 lg:block">
                 <PropertyMapDesktopLayerBar
                   showZoningColors={showZoningColors}

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -168,7 +168,8 @@ function pointInPolygonGeometry(lng: number, lat: number, geom: Geometry): boole
   return false;
 }
 
-function mlsAreaForPoint(
+/** Full MLS market area name only (`District`); never the short code (`Abbrv`). */
+function mlsDistrictNameForPoint(
   lng: number,
   lat: number,
   fc: FeatureCollection<Geometry, { Abbrv?: string; District?: string }> | null,
@@ -178,12 +179,18 @@ function mlsAreaForPoint(
     if (!feature.geometry) continue;
     if (!pointInPolygonGeometry(lng, lat, feature.geometry)) continue;
     const district = String(feature.properties?.District ?? "").trim();
-    const abbrv = String(feature.properties?.Abbrv ?? "").trim();
-    if (district && abbrv) return `${district} (${abbrv})`;
     if (district) return district;
-    if (abbrv) return abbrv;
   }
   return null;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
 }
 
 /** Fill opacity with hover lift (requires `promoteId: "parcel_id"` + feature-state). */
@@ -349,6 +356,7 @@ export function ZoningMap({
   const linkSoldGeoJsonRef = useRef(linkSoldGeoJson);
   const onLinkListingPinSelectRef = useRef(onLinkListingPinSelect);
   const showLinkPinsRef = useRef(showLinkPins);
+  const reDistrictsGeoJsonRef = useRef(reDistrictsGeoJson);
 
   useEffect(() => {
     rentalGeoJsonRef.current = rentalGeoJson ?? null;
@@ -361,6 +369,10 @@ export function ZoningMap({
   useEffect(() => {
     linkSoldGeoJsonRef.current = linkSoldGeoJson ?? null;
   }, [linkSoldGeoJson]);
+
+  useEffect(() => {
+    reDistrictsGeoJsonRef.current = reDistrictsGeoJson ?? null;
+  }, [reDistrictsGeoJson]);
 
   useEffect(() => {
     onLinkListingPinSelectRef.current = onLinkListingPinSelect;
@@ -832,8 +844,13 @@ export function ZoningMap({
         }
 
         if (!popupRef.current) return;
-        const address = feature.properties?.location ?? "Address unavailable";
-        const mlsArea = mlsAreaForPoint(event.lngLat.lng, event.lngLat.lat, reDistrictsGeoJson ?? null) ?? "Unknown";
+        const addressRaw = String(feature.properties?.location ?? "").trim() || "Address unavailable";
+        const zoningRaw = String(feature.properties?.zoning ?? "").trim() || "Unknown";
+        const mlsDistrict =
+          mlsDistrictNameForPoint(event.lngLat.lng, event.lngLat.lat, reDistrictsGeoJsonRef.current) ?? "Unknown";
+        const address = escapeHtml(addressRaw);
+        const zoning = escapeHtml(zoningRaw);
+        const mlsArea = escapeHtml(mlsDistrict);
 
         popupRef.current
           .setLngLat(event.lngLat)
@@ -841,6 +858,7 @@ export function ZoningMap({
             `<div style="font-size:12px;">
               <div><strong>Address:</strong> ${address}</div>
               <div><strong>MLS Area:</strong> ${mlsArea}</div>
+              <div><strong>Zoning:</strong> ${zoning}</div>
             </div>`,
           )
           .addTo(map);

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -109,6 +109,21 @@ const RE_DISTRICT_FILL_OPACITY_DEFAULT = 0.62 * RE_DISTRICT_FILL_OPACITY_SCALE;
 const RE_DISTRICT_FILL_OPACITY_HIGHLIGHT = 0.78 * RE_DISTRICT_FILL_OPACITY_SCALE;
 const RE_DISTRICT_FILL_OPACITY_DIM = 0.42 * RE_DISTRICT_FILL_OPACITY_SCALE;
 
+/** Between-MLS-area borders — half the prior zoom-based line widths. */
+const RE_DISTRICT_BOUNDARY_LINE_WIDTH: mapboxgl.ExpressionSpecification = [
+  "interpolate",
+  ["linear"],
+  ["zoom"],
+  10,
+  1,
+  12,
+  1.5,
+  14,
+  2,
+  16,
+  2.75,
+];
+
 function listingOverlayLayerIds(map: mapboxgl.Map): string[] {
   const ids = [
     "rentals-clusters",
@@ -1170,7 +1185,7 @@ export function ZoningMap({
             layout: { visibility: "none" },
             paint: {
               "line-color": "#0f172a",
-              "line-width": ["interpolate", ["linear"], ["zoom"], 10, 2, 12, 3, 14, 4, 16, 5.5],
+              "line-width": RE_DISTRICT_BOUNDARY_LINE_WIDTH,
               "line-opacity": 0.95,
             },
           },
@@ -1203,7 +1218,7 @@ export function ZoningMap({
               layout: { visibility: "none" },
               paint: {
                 "line-color": "#0f172a",
-                "line-width": ["interpolate", ["linear"], ["zoom"], 10, 2, 12, 3, 14, 4, 16, 5.5],
+                "line-width": RE_DISTRICT_BOUNDARY_LINE_WIDTH,
                 "line-opacity": 0.95,
               },
             },

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -102,6 +102,13 @@ const PARCEL_OUTLINE_MIN_ZOOM = 15;
 /** Parcel fill when zoning colors are hidden (single tone over basemap). */
 const PARCEL_FILL_NEUTRAL = "#cbd5e1";
 
+/** MLS (RE) district polygon fill — scaled down 30% from prior tuning for a lighter overlay. */
+const RE_DISTRICT_FILL_OPACITY_SCALE = 0.7;
+const RE_DISTRICT_FILL_OPACITY_INITIAL = 0.55 * RE_DISTRICT_FILL_OPACITY_SCALE;
+const RE_DISTRICT_FILL_OPACITY_DEFAULT = 0.62 * RE_DISTRICT_FILL_OPACITY_SCALE;
+const RE_DISTRICT_FILL_OPACITY_HIGHLIGHT = 0.78 * RE_DISTRICT_FILL_OPACITY_SCALE;
+const RE_DISTRICT_FILL_OPACITY_DIM = 0.42 * RE_DISTRICT_FILL_OPACITY_SCALE;
+
 function listingOverlayLayerIds(map: mapboxgl.Map): string[] {
   const ids = [
     "rentals-clusters",
@@ -249,11 +256,11 @@ function syncParcelAndReOverlay(
       map.setPaintProperty("re-districts-fill", "fill-opacity", [
         "case",
         ["==", ["get", "Abbrv"], hi],
-        0.78,
-        0.42,
+        RE_DISTRICT_FILL_OPACITY_HIGHLIGHT,
+        RE_DISTRICT_FILL_OPACITY_DIM,
       ]);
     } else {
-      map.setPaintProperty("re-districts-fill", "fill-opacity", 0.62);
+      map.setPaintProperty("re-districts-fill", "fill-opacity", RE_DISTRICT_FILL_OPACITY_DEFAULT);
     }
   }
 }
@@ -1149,7 +1156,7 @@ export function ZoningMap({
             layout: { visibility: "none" },
             paint: {
               "fill-color": reDistrictFillColorExpression() as mapboxgl.ExpressionSpecification,
-              "fill-opacity": 0.55,
+              "fill-opacity": RE_DISTRICT_FILL_OPACITY_INITIAL,
             },
           },
           "parcels-fill",

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -1001,10 +1001,14 @@ export function ZoningMap({
     const map = mapRef.current;
     if (!map || !reDistrictsGeoJson?.features?.length) return;
 
-    const ensureLayers = () => {
-      if (!map.isStyleLoaded() || !map.getLayer("parcels-fill")) return;
+    let cancelled = false;
+
+    /** Returns true once MLS district sources/layers are in place (or already were). */
+    const ensureLayers = (): boolean => {
+      if (cancelled) return true;
+      if (!map.isStyleLoaded() || !map.getLayer("parcels-fill")) return false;
       const data = reDistrictsGeoJson;
-      if (!data) return;
+      if (!data) return true;
 
       const boundaryLines = reDistrictPolygonsToBoundaryLines(
         data as FeatureCollection<Geometry, Record<string, unknown>>,
@@ -1081,13 +1085,34 @@ export function ZoningMap({
         if (map.getLayer("re-districts-outline")) map.removeLayer("re-districts-outline");
       }
       syncParcelAndReOverlay(map, { showZoningColors, parcelBaseLayer, highlightedReDistrictAbbrv });
+      return true;
     };
 
-    if (map.isStyleLoaded()) ensureLayers();
-    else map.once("load", ensureLayers);
+    /**
+     * RE GeoJSON often finishes loading before the map `load` handler adds `parcels-fill`.
+     * Previously `ensureLayers` no-op'd with no retry, so MLS Areas stayed blank until another
+     * prop tick (e.g. toggling the overlay). Retry on `load` and `idle` until base layers exist.
+     */
+    let attachAttempts = 0;
+    const maxAttachAttempts = 48;
+    const scheduleAttachWhenReady = () => {
+      if (cancelled) return;
+      if (ensureLayers()) return;
+      attachAttempts += 1;
+      if (attachAttempts > maxAttachAttempts) return;
+      if (!map.isStyleLoaded()) {
+        map.once("load", scheduleAttachWhenReady);
+      } else {
+        map.once("idle", scheduleAttachWhenReady);
+      }
+    };
+
+    scheduleAttachWhenReady();
 
     return () => {
-      map.off("load", ensureLayers);
+      cancelled = true;
+      map.off("load", scheduleAttachWhenReady);
+      map.off("idle", scheduleAttachWhenReady);
     };
   }, [reDistrictsGeoJson, showZoningColors, parcelBaseLayer, highlightedReDistrictAbbrv]);
 

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -332,6 +332,8 @@ export function ZoningMap({
   const highlightSoldRef = useRef(highlightSoldParcels);
   const soldParcelIdsRef = useRef(soldParcelIds);
   const showZoningColorsRef = useRef(showZoningColors);
+  const parcelBaseLayerRef = useRef(parcelBaseLayer);
+  const highlightedReDistrictAbbrvRef = useRef(highlightedReDistrictAbbrv);
   const onRentalPinSelectRef = useRef(onRentalPinSelect);
   const onViewportBoundsChangeRef = useRef(onViewportBoundsChange);
   const showRentalPinsRef = useRef(showRentalPins);
@@ -367,10 +369,21 @@ export function ZoningMap({
     highlightSoldRef.current = highlightSoldParcels;
     soldParcelIdsRef.current = soldParcelIds;
     showZoningColorsRef.current = showZoningColors;
+    parcelBaseLayerRef.current = parcelBaseLayer;
+    highlightedReDistrictAbbrvRef.current = highlightedReDistrictAbbrv;
     onRentalPinSelectRef.current = onRentalPinSelect;
     onViewportBoundsChangeRef.current = onViewportBoundsChange;
     showRentalPinsRef.current = showRentalPins;
-  }, [highlightSoldParcels, soldParcelIds, showZoningColors, onRentalPinSelect, onViewportBoundsChange, showRentalPins]);
+  }, [
+    highlightSoldParcels,
+    soldParcelIds,
+    showZoningColors,
+    parcelBaseLayer,
+    highlightedReDistrictAbbrv,
+    onRentalPinSelect,
+    onViewportBoundsChange,
+    showRentalPins,
+  ]);
 
   const applySoldParcelHighlight = (map: mapboxgl.Map) => {
     if (!map.getLayer("parcels-sold-outline")) return;
@@ -994,7 +1007,22 @@ export function ZoningMap({
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
-    syncParcelAndReOverlay(map, { showZoningColors, parcelBaseLayer, highlightedReDistrictAbbrv });
+    const runSync = () =>
+      syncParcelAndReOverlay(map, {
+        showZoningColors: showZoningColorsRef.current,
+        parcelBaseLayer: parcelBaseLayerRef.current,
+        highlightedReDistrictAbbrv: highlightedReDistrictAbbrvRef.current,
+      });
+    runSync();
+    /** MLS overlay needs RE layers; they may land a frame after `parcelBaseLayer` updates — bump sync. */
+    if (parcelBaseLayer !== "re_market_areas") return;
+    const bump = () => runSync();
+    const rafId = requestAnimationFrame(bump);
+    map.once("idle", bump);
+    return () => {
+      cancelAnimationFrame(rafId);
+      map.off("idle", bump);
+    };
   }, [showZoningColors, parcelBaseLayer, highlightedReDistrictAbbrv]);
 
   useEffect(() => {
@@ -1005,7 +1033,7 @@ export function ZoningMap({
 
     /** Returns true once MLS district sources/layers are in place (or already were). */
     const ensureLayers = (): boolean => {
-      if (cancelled) return true;
+      if (cancelled) return false;
       if (!map.isStyleLoaded() || !map.getLayer("parcels-fill")) return false;
       const data = reDistrictsGeoJson;
       if (!data) return true;
@@ -1084,7 +1112,11 @@ export function ZoningMap({
         }
         if (map.getLayer("re-districts-outline")) map.removeLayer("re-districts-outline");
       }
-      syncParcelAndReOverlay(map, { showZoningColors, parcelBaseLayer, highlightedReDistrictAbbrv });
+      syncParcelAndReOverlay(map, {
+        showZoningColors: showZoningColorsRef.current,
+        parcelBaseLayer: parcelBaseLayerRef.current,
+        highlightedReDistrictAbbrv: highlightedReDistrictAbbrvRef.current,
+      });
       return true;
     };
 

--- a/src/components/zoning/ZoningMap.tsx
+++ b/src/components/zoning/ZoningMap.tsx
@@ -15,7 +15,11 @@ import {
   parseMapViewFromSearchParams,
 } from "@/lib/map-view-url";
 import { mapboxZoningFillColorExpression } from "@/lib/zoning-colors";
-import { reDistrictFillColorExpression, reDistrictPolygonsToBoundaryLines } from "@/lib/re-districts-map";
+import {
+  reDistrictFillColorExpression,
+  reDistrictPolygonsToBoundaryLines,
+  reDistrictPolygonsToLabelPoints,
+} from "@/lib/re-districts-map";
 
 /** Parcel fill + optional RE (MLS-style) market polygons under parcels. */
 export type ParcelBaseMapLayer = "tax_zoning" | "re_market_areas" | "none";
@@ -228,6 +232,9 @@ function syncParcelAndReOverlay(
   }
   if (map.getLayer("re-districts-outline")) {
     map.setLayoutProperty("re-districts-outline", "visibility", "none");
+  }
+  if (map.getLayer("re-districts-label")) {
+    map.setLayoutProperty("re-districts-label", "visibility", showReOverlay ? "visible" : "none");
   }
   if (showReOverlay) {
     const hi = (opts.highlightedReDistrictAbbrv ?? "").trim();
@@ -1041,6 +1048,73 @@ export function ZoningMap({
       const boundaryLines = reDistrictPolygonsToBoundaryLines(
         data as FeatureCollection<Geometry, Record<string, unknown>>,
       );
+      const labelPoints = reDistrictPolygonsToLabelPoints(
+        data as FeatureCollection<Geometry, Record<string, unknown>>,
+      );
+
+      const upsertReDistrictLabelLayer = () => {
+        const textField: mapboxgl.ExpressionSpecification = [
+          "case",
+          [">", ["length", ["coalesce", ["get", "District"], ""]], 0],
+          ["get", "District"],
+          ["coalesce", ["get", "Abbrv"], ""],
+        ];
+        if (!map.getSource("re-districts-labels")) {
+          map.addSource("re-districts-labels", { type: "geojson", data: labelPoints });
+          map.addLayer(
+            {
+              id: "re-districts-label",
+              type: "symbol",
+              source: "re-districts-labels",
+              minzoom: 10,
+              layout: {
+                visibility: "none",
+                "text-field": textField,
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+                "text-size": ["interpolate", ["linear"], ["zoom"], 10, 10, 12, 11, 14, 12.5, 16, 13.5],
+                "text-allow-overlap": true,
+                "text-padding": 4,
+              },
+              paint: {
+                "text-color": "#0f172a",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 3,
+                "text-halo-blur": 0.35,
+                "text-opacity": ["interpolate", ["linear"], ["zoom"], 9.5, 0, 10, 1],
+              },
+            },
+            "parcels-fill",
+          );
+        } else {
+          (map.getSource("re-districts-labels") as mapboxgl.GeoJSONSource).setData(labelPoints);
+          if (!map.getLayer("re-districts-label")) {
+            map.addLayer(
+              {
+                id: "re-districts-label",
+                type: "symbol",
+                source: "re-districts-labels",
+                minzoom: 10,
+                layout: {
+                  visibility: "none",
+                  "text-field": textField,
+                  "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+                  "text-size": ["interpolate", ["linear"], ["zoom"], 10, 10, 12, 11, 14, 12.5, 16, 13.5],
+                  "text-allow-overlap": true,
+                  "text-padding": 4,
+                },
+                paint: {
+                  "text-color": "#0f172a",
+                  "text-halo-color": "#ffffff",
+                  "text-halo-width": 3,
+                  "text-halo-blur": 0.35,
+                  "text-opacity": ["interpolate", ["linear"], ["zoom"], 9.5, 0, 10, 1],
+                },
+              },
+              "parcels-fill",
+            );
+          }
+        }
+      };
 
       if (!map.getSource("re-districts")) {
         if (map.getLayer("re-districts-outline")) map.removeLayer("re-districts-outline");
@@ -1077,6 +1151,7 @@ export function ZoningMap({
           },
           "parcels-sold-outline",
         );
+        upsertReDistrictLabelLayer();
       } else {
         (map.getSource("re-districts") as mapboxgl.GeoJSONSource).setData(data);
         let lineSrc = map.getSource("re-districts-boundaries") as mapboxgl.GeoJSONSource | undefined;
@@ -1111,6 +1186,7 @@ export function ZoningMap({
           );
         }
         if (map.getLayer("re-districts-outline")) map.removeLayer("re-districts-outline");
+        upsertReDistrictLabelLayer();
       }
       syncParcelAndReOverlay(map, {
         showZoningColors: showZoningColorsRef.current,

--- a/src/lib/link-listings-parcel-match.ts
+++ b/src/lib/link-listings-parcel-match.ts
@@ -59,6 +59,8 @@ export type LinkListingMapPoint = {
   livingAreaSqft: number | null;
   renoHint: boolean;
   townWalkHint: boolean;
+  /** Heuristic from remarks / marketing (not a dedicated MLS pool field). */
+  hasPool: boolean;
 };
 
 export type LinkListingPinProperties = {
@@ -83,6 +85,7 @@ export type LinkListingPinProperties = {
   livingAreaSqft: number | null;
   renoHint: boolean;
   townWalkHint: boolean;
+  hasPool: boolean;
   /** Parcel centroid pin — used for satellite hero when listing has no photo. */
   longitude?: number | null;
   latitude?: number | null;
@@ -123,6 +126,12 @@ function linkRenovatedRecent(row: LinkListingRow): boolean {
 
 function linkTownWalkHint(row: LinkListingRow): boolean {
   return /\b(downtown|in town|in-town|town center|center of town|historic district|main street|steps to town|walk to town)\b/i.test(
+    linkMarketingBlob(row),
+  );
+}
+
+function linkPoolHint(row: LinkListingRow): boolean {
+  return /\b(pool|heated pool|in-?ground pool|swimming pool|gunite pool|pool & spa|pool and spa)\b/i.test(
     linkMarketingBlob(row),
   );
 }
@@ -204,6 +213,7 @@ export function matchLinkListingToPoint(
     livingAreaSqft: pickLivingAreaSqft(row),
     renoHint: linkRenovatedRecent(row),
     townWalkHint: linkTownWalkHint(row),
+    hasPool: linkPoolHint(row),
   };
 }
 
@@ -370,6 +380,7 @@ export function linkMapPointsToGeoJson(points: LinkListingMapPoint[]): FeatureCo
         livingAreaSqft: p.livingAreaSqft,
         renoHint: p.renoHint,
         townWalkHint: p.townWalkHint,
+        hasPool: p.hasPool,
         longitude: p.longitude,
         latitude: p.latitude,
       },

--- a/src/lib/property-map-filters.ts
+++ b/src/lib/property-map-filters.ts
@@ -24,6 +24,20 @@ export type RentalFiltersState = {
 
 export type LinkPropertyTypeKey = "houses" | "land" | "commercial";
 
+/** Sold-pool “closed in the last …” window; empty = no date filter. */
+export type LinkFiltersSoldInLast = "" | "7d" | "30d" | "90d" | "6m" | "12m" | "24m" | "36m";
+
+/** Preset rows for the “Sold in last” control (no “any time” row — empty state uses a hidden `option`). */
+export const LINK_FILTERS_SOLD_IN_LAST_OPTIONS: { value: Exclude<LinkFiltersSoldInLast, "">; label: string }[] = [
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "90d", label: "90 days" },
+  { value: "6m", label: "6 months" },
+  { value: "12m", label: "12 months" },
+  { value: "24m", label: "24 months" },
+  { value: "36m", label: "36 months" },
+];
+
 export type LinkFiltersState = {
   pricePreset: "" | "1-3" | "3-6" | "6+";
   minPrice: string;
@@ -33,15 +47,11 @@ export type LinkFiltersState = {
   minLotAcres: string;
   newConstruction: boolean;
   waterfront: boolean;
-  /** Keyword “walk to town” style (remarks / marketing). */
-  walkToTown: boolean;
-  /** Recently renovated / like-new (remarks heuristic). */
-  renoRecent: boolean;
+  /** Pool / swimming pool (remarks heuristic on LINK pins). */
+  pool: boolean;
   propertyTypes: LinkPropertyTypeKey[];
-  /** yyyy-mm-dd inclusive lower bound on sold close date (sold pool). */
-  soldCloseAfter: string;
-  /** yyyy-mm-dd inclusive upper bound on sold close date (sold pool). */
-  soldCloseBefore: string;
+  /** Sold listings only: require close date within this lookback from “now”. */
+  soldInLast: LinkFiltersSoldInLast;
   minDom: string;
   maxDom: string;
   /** Max $/sqft when living area is present on the pin (LINK feed). */
@@ -72,11 +82,9 @@ export const DEFAULT_LINK_FILTERS: LinkFiltersState = {
   minLotAcres: "",
   newConstruction: false,
   waterfront: false,
-  walkToTown: false,
-  renoRecent: false,
+  pool: false,
   propertyTypes: [],
-  soldCloseAfter: "",
-  soldCloseBefore: "",
+  soldInLast: "",
   minDom: "",
   maxDom: "",
   maxPricePerSqft: "",
@@ -196,10 +204,9 @@ export function countActiveLinkFilters(f: LinkFiltersState): number {
   if (f.minLotAcres.trim()) n += 1;
   if (f.newConstruction) n += 1;
   if (f.waterfront) n += 1;
-  if (f.walkToTown) n += 1;
-  if (f.renoRecent) n += 1;
+  if (f.pool) n += 1;
   if (f.propertyTypes.length) n += 1;
-  if (f.soldCloseAfter.trim() || f.soldCloseBefore.trim()) n += 1;
+  if (f.soldInLast) n += 1;
   if (f.minDom.trim() || f.maxDom.trim()) n += 1;
   if (f.maxPricePerSqft.trim()) n += 1;
   return n;
@@ -246,6 +253,22 @@ function linkTransactionPrice(p: LinkListingPinProperties, pool: "active" | "sol
   return typeof p.listPriceNum === "number" && !Number.isNaN(p.listPriceNum) ? p.listPriceNum : 0;
 }
 
+/** Start of “sold in last …” window (inclusive), in ms since epoch. */
+export function soldInLastStartMs(preset: LinkFiltersSoldInLast, now: Date): number | null {
+  if (!preset) return null;
+  const DAY = 86_400_000;
+  const t = now.getTime();
+  if (preset === "7d") return t - 7 * DAY;
+  if (preset === "30d") return t - 30 * DAY;
+  if (preset === "90d") return t - 90 * DAY;
+  const months =
+    preset === "6m" ? 6 : preset === "12m" ? 12 : preset === "24m" ? 24 : preset === "36m" ? 36 : 0;
+  if (!months) return null;
+  const d = new Date(t);
+  d.setMonth(d.getMonth() - months);
+  return d.getTime();
+}
+
 export function filterLinkFeatureCollection(
   fc: FeatureCollection<Point, LinkListingPinProperties>,
   f: LinkFiltersState,
@@ -270,9 +293,9 @@ export function filterLinkFeatureCollection(
   const minDom = parsePositiveInt(f.minDom);
   const maxDom = parsePositiveInt(f.maxDom);
   const maxPpsf = parsePositiveFloat(f.maxPricePerSqft);
-  const afterMs = f.soldCloseAfter.trim() ? parseListingDateMs(f.soldCloseAfter) : null;
-  const beforeMs = f.soldCloseBefore.trim() ? parseListingDateMs(f.soldCloseBefore) : null;
   const now = new Date();
+  const soldWindowStartMs = pool === "sold" ? soldInLastStartMs(f.soldInLast, now) : null;
+  const soldWindowEndMs = now.getTime();
 
   const feats = fc.features.filter((feat) => {
     const p = feat.properties;
@@ -297,8 +320,7 @@ export function filterLinkFeatureCollection(
     }
     if (f.newConstruction && !nc) return false;
     if (f.waterfront && !wf) return false;
-    if (f.walkToTown && !p.townWalkHint) return false;
-    if (f.renoRecent && !p.renoHint) return false;
+    if (f.pool && !p.hasPool) return false;
     if (!linkMatchesPropertyTypes(p.propertyType, f.propertyTypes)) return false;
 
     if (maxPpsf != null) {
@@ -307,11 +329,11 @@ export function filterLinkFeatureCollection(
       if (price / sq > maxPpsf) return false;
     }
 
-    if (pool === "sold" && (afterMs != null || beforeMs != null)) {
+    if (pool === "sold" && soldWindowStartMs != null) {
       const closeMs = parseListingDateMs(p.closeDate);
       if (closeMs == null) return false;
-      if (afterMs != null && closeMs < afterMs) return false;
-      if (beforeMs != null && closeMs >= beforeMs + 86_400_000) return false;
+      if (closeMs < soldWindowStartMs) return false;
+      if (closeMs > soldWindowEndMs) return false;
     }
 
     if (minDom != null || maxDom != null) {

--- a/src/lib/property-map-filters.ts
+++ b/src/lib/property-map-filters.ts
@@ -27,6 +27,23 @@ export type LinkPropertyTypeKey = "houses" | "land" | "commercial";
 /** Sold-pool “closed in the last …” window; empty = no date filter. */
 export type LinkFiltersSoldInLast = "" | "7d" | "30d" | "90d" | "6m" | "12m" | "24m" | "36m";
 
+/**
+ * Default sold closings lookback for `/api/map/link-listings` bbox requests (days).
+ * Client-side `soldInLast` narrows further; when cleared, pins still respect this feed window.
+ */
+export const LINK_MAP_DEFAULT_SOLD_FEED_DAYS = 1095;
+
+/** Human label for {@link LINK_MAP_DEFAULT_SOLD_FEED_DAYS} (keep in sync with map API default). */
+export function linkMapImplicitSoldFeedLabel(): string {
+  const d = LINK_MAP_DEFAULT_SOLD_FEED_DAYS;
+  if (d >= 330) {
+    const y = Math.max(1, Math.round(d / 365));
+    return y === 1 ? "~1 year" : `~${y} years`;
+  }
+  const m = Math.max(1, Math.round(d / 30));
+  return `~${m} months`;
+}
+
 /** Preset rows for the “Sold in last” control (no “any time” row — empty state uses a hidden `option`). */
 export const LINK_FILTERS_SOLD_IN_LAST_OPTIONS: { value: Exclude<LinkFiltersSoldInLast, "">; label: string }[] = [
   { value: "7d", label: "7 days" },
@@ -216,6 +233,8 @@ export type MapAppliedFilterChip = {
   id: string;
   source: "rental" | "link";
   label: string;
+  /** When false, toolbar shows the pill without a remove control (informational). */
+  dismissable?: boolean;
 };
 
 function soldInLastPresetLabel(preset: LinkFiltersSoldInLast): string {
@@ -275,12 +294,21 @@ export function buildMapAppliedFilterChips(params: {
       const lab = LINK_PROPERTY_TYPE_LABELS.find((x) => x.key === k)?.label ?? k;
       chips.push({ id: `link:ptype:${k}`, source: "link", label: lab });
     }
-    if (showSold && l.soldInLast) {
-      chips.push({
-        id: "link:soldInLast",
-        source: "link",
-        label: `Sold: last ${soldInLastPresetLabel(l.soldInLast)}`,
-      });
+    if (showSold) {
+      if (l.soldInLast) {
+        chips.push({
+          id: "link:soldInLast",
+          source: "link",
+          label: `Sold: ${soldInLastPresetLabel(l.soldInLast)}`,
+        });
+      } else {
+        chips.push({
+          id: "link:soldFeedImplicit",
+          source: "link",
+          label: `Sold: ${linkMapImplicitSoldFeedLabel()}`,
+          dismissable: false,
+        });
+      }
     }
     if (l.minDom.trim()) chips.push({ id: "link:domMin", source: "link", label: `DOM ≥ ${l.minDom}` });
     if (l.maxDom.trim()) chips.push({ id: "link:domMax", source: "link", label: `DOM ≤ ${l.maxDom}` });

--- a/src/lib/property-map-filters.ts
+++ b/src/lib/property-map-filters.ts
@@ -212,6 +212,147 @@ export function countActiveLinkFilters(f: LinkFiltersState): number {
   return n;
 }
 
+export type MapAppliedFilterChip = {
+  id: string;
+  source: "rental" | "link";
+  label: string;
+};
+
+function soldInLastPresetLabel(preset: LinkFiltersSoldInLast): string {
+  if (!preset) return "";
+  return LINK_FILTERS_SOLD_IN_LAST_OPTIONS.find((o) => o.value === preset)?.label ?? preset;
+}
+
+function removeLinkPropertyTypeKey(keys: LinkPropertyTypeKey[], k: LinkPropertyTypeKey): LinkPropertyTypeKey[] {
+  return keys.filter((x) => x !== k);
+}
+
+/** Toolbar chips for active vacation-rental / MLS filters (IDs consumed by `removeMapAppliedFilterChip`). */
+export function buildMapAppliedFilterChips(params: {
+  rental: RentalFiltersState;
+  link: LinkFiltersState;
+  showRent: boolean;
+  showLink: boolean;
+  showSold: boolean;
+}): MapAppliedFilterChip[] {
+  const { rental: r, link: l, showRent, showLink, showSold } = params;
+  const chips: MapAppliedFilterChip[] = [];
+
+  if (showRent) {
+    if (r.minRate.trim() || r.maxRate.trim()) {
+      const a = r.minRate.trim() ? `$${r.minRate.trim()}` : "Any";
+      const b = r.maxRate.trim() ? `$${r.maxRate.trim()}` : "Any";
+      chips.push({ id: "rent:rate", source: "rental", label: `Rate (${r.ratePeriod}): ${a} – ${b}` });
+    }
+    if (r.beachDistance === "walk") chips.push({ id: "rent:beach", source: "rental", label: "Walk to beach" });
+    if (r.beachDistance === "not_walk") chips.push({ id: "rent:beach", source: "rental", label: "Not walk-to-beach" });
+    if (r.minBedrooms.trim()) chips.push({ id: "rent:beds", source: "rental", label: `Beds ≥ ${r.minBedrooms}` });
+    if (r.minBaths.trim()) chips.push({ id: "rent:baths", source: "rental", label: `Baths ≥ ${r.minBaths}` });
+    if (r.minOccupancy.trim()) chips.push({ id: "rent:occ", source: "rental", label: `Sleeps ≥ ${r.minOccupancy}` });
+    if (r.pool) chips.push({ id: "rent:pool", source: "rental", label: "Pool" });
+    if (r.waterfront) chips.push({ id: "rent:water", source: "rental", label: "Waterfront / water view" });
+    if (r.petFriendly) chips.push({ id: "rent:pets", source: "rental", label: "Pet-friendly" });
+    if (r.renovated) chips.push({ id: "rent:reno", source: "rental", label: "Renovated / like-new" });
+    if (r.townWalk) chips.push({ id: "rent:town", source: "rental", label: "Walk to Town" });
+  }
+
+  if (showLink) {
+    if (l.pricePreset === "1-3") chips.push({ id: "link:price:preset", source: "link", label: "Price: $1M – $3M" });
+    else if (l.pricePreset === "3-6") chips.push({ id: "link:price:preset", source: "link", label: "Price: $3M – $6M" });
+    else if (l.pricePreset === "6+") chips.push({ id: "link:price:preset", source: "link", label: "Price: $6M+" });
+    else if (l.minPrice.trim() || l.maxPrice.trim()) {
+      const a = l.minPrice.trim() ? l.minPrice.trim() : "Any";
+      const b = l.maxPrice.trim() ? l.maxPrice.trim() : "Any";
+      chips.push({ id: "link:price:custom", source: "link", label: `List price: ${a} – ${b}` });
+    }
+    if (l.minBeds.trim()) chips.push({ id: "link:beds", source: "link", label: `Beds ≥ ${l.minBeds}` });
+    if (l.minBaths.trim()) chips.push({ id: "link:baths", source: "link", label: `Baths ≥ ${l.minBaths}` });
+    if (l.minLotAcres.trim()) chips.push({ id: "link:lot", source: "link", label: `Lot ≥ ${l.minLotAcres} ac` });
+    if (l.newConstruction) chips.push({ id: "link:new", source: "link", label: "New construction" });
+    if (l.waterfront) chips.push({ id: "link:water", source: "link", label: "Waterfront" });
+    if (l.pool) chips.push({ id: "link:pool", source: "link", label: "Pool" });
+    for (const k of l.propertyTypes) {
+      const lab = LINK_PROPERTY_TYPE_LABELS.find((x) => x.key === k)?.label ?? k;
+      chips.push({ id: `link:ptype:${k}`, source: "link", label: lab });
+    }
+    if (showSold && l.soldInLast) {
+      chips.push({
+        id: "link:soldInLast",
+        source: "link",
+        label: `Sold: last ${soldInLastPresetLabel(l.soldInLast)}`,
+      });
+    }
+    if (l.minDom.trim()) chips.push({ id: "link:domMin", source: "link", label: `DOM ≥ ${l.minDom}` });
+    if (l.maxDom.trim()) chips.push({ id: "link:domMax", source: "link", label: `DOM ≤ ${l.maxDom}` });
+    if (l.maxPricePerSqft.trim()) chips.push({ id: "link:ppsf", source: "link", label: `≤ $${l.maxPricePerSqft.trim()}/sq ft` });
+  }
+
+  return chips;
+}
+
+/** Apply a single chip removal (toolbar dismiss). */
+export function removeMapAppliedFilterChip(
+  chipId: string,
+  rental: RentalFiltersState,
+  link: LinkFiltersState,
+): { rental: RentalFiltersState; link: LinkFiltersState } {
+  let r = { ...rental };
+  let l = { ...link };
+
+  if (chipId === "rent:rate") {
+    r = { ...r, minRate: "", maxRate: "" };
+  } else if (chipId === "rent:beach") {
+    r = { ...r, beachDistance: "any" };
+  } else if (chipId === "rent:beds") {
+    r = { ...r, minBedrooms: "" };
+  } else if (chipId === "rent:baths") {
+    r = { ...r, minBaths: "" };
+  } else if (chipId === "rent:occ") {
+    r = { ...r, minOccupancy: "" };
+  } else if (chipId === "rent:pool") {
+    r = { ...r, pool: false };
+  } else if (chipId === "rent:water") {
+    r = { ...r, waterfront: false };
+  } else if (chipId === "rent:pets") {
+    r = { ...r, petFriendly: false };
+  } else if (chipId === "rent:reno") {
+    r = { ...r, renovated: false };
+  } else if (chipId === "rent:town") {
+    r = { ...r, townWalk: false };
+  } else if (chipId === "link:price:preset") {
+    l = { ...l, pricePreset: "", minPrice: "", maxPrice: "" };
+  } else if (chipId === "link:price:custom") {
+    l = { ...l, minPrice: "", maxPrice: "" };
+  } else if (chipId === "link:beds") {
+    l = { ...l, minBeds: "" };
+  } else if (chipId === "link:baths") {
+    l = { ...l, minBaths: "" };
+  } else if (chipId === "link:lot") {
+    l = { ...l, minLotAcres: "" };
+  } else if (chipId === "link:new") {
+    l = { ...l, newConstruction: false };
+  } else if (chipId === "link:water") {
+    l = { ...l, waterfront: false };
+  } else if (chipId === "link:pool") {
+    l = { ...l, pool: false };
+  } else if (chipId === "link:soldInLast") {
+    l = { ...l, soldInLast: "" };
+  } else if (chipId === "link:domMin") {
+    l = { ...l, minDom: "" };
+  } else if (chipId === "link:domMax") {
+    l = { ...l, maxDom: "" };
+  } else if (chipId === "link:ppsf") {
+    l = { ...l, maxPricePerSqft: "" };
+  } else if (chipId.startsWith("link:ptype:")) {
+    const k = chipId.slice("link:ptype:".length) as LinkPropertyTypeKey;
+    if (k === "houses" || k === "land" || k === "commercial") {
+      l = { ...l, propertyTypes: removeLinkPropertyTypeKey(l.propertyTypes, k) };
+    }
+  }
+
+  return { rental: r, link: l };
+}
+
 export function applyRentalFilters(results: NrMapRentalResult[], f: RentalFiltersState): NrMapRentalResult[] {
   const minR = parseMoney(f.minRate);
   const maxR = parseMoney(f.maxRate);

--- a/src/lib/re-districts-map.ts
+++ b/src/lib/re-districts-map.ts
@@ -1,4 +1,4 @@
-import type { Feature, FeatureCollection, Geometry, LineString, MultiPolygon, Polygon } from "geojson";
+import type { Feature, FeatureCollection, Geometry, LineString, MultiPolygon, Point, Polygon } from "geojson";
 
 /**
  * Mapbox `line` layers only render LineString / MultiLineString — not Polygon rings.
@@ -31,6 +31,83 @@ export function reDistrictPolygonsToBoundaryLines<P extends Record<string, unkno
             geometry: { type: "LineString", coordinates: ring },
           });
         }
+      }
+    }
+  }
+  return { type: "FeatureCollection", features };
+}
+
+/** Shoelace centroid of one ring (lng/lat); falls back to vertex average for degenerate rings. */
+function centroidOfRingLngLat(ring: number[][]): [number, number] {
+  const n = ring.length;
+  if (n < 3) return [(ring[0]?.[0] ?? 0) as number, (ring[0]?.[1] ?? 0) as number];
+  let twice = 0;
+  let cx = 0;
+  let cy = 0;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const p = ring[i]!;
+    const q = ring[j]!;
+    const cr = q[0] * p[1] - p[0] * q[1];
+    twice += cr;
+    cx += (p[0] + q[0]) * cr;
+    cy += (p[1] + q[1]) * cr;
+  }
+  if (Math.abs(twice) < 1e-18) {
+    let sx = 0;
+    let sy = 0;
+    let c = 0;
+    for (const pt of ring) {
+      if (pt.length >= 2) {
+        sx += pt[0];
+        sy += pt[1];
+        c += 1;
+      }
+    }
+    return c ? [sx / c, sy / c] : [0, 0];
+  }
+  const a = twice / 2;
+  return [cx / (6 * a), cy / (6 * a)];
+}
+
+function ringBBoxAreaLngLat(ring: number[][]): number {
+  const b = ringBounds(ring);
+  if (!b) return 0;
+  return (b[2] - b[0]) * (b[3] - b[1]);
+}
+
+/**
+ * One Point feature per district (polygon centroid) for symbol labels.
+ * MultiPolygon: uses the exterior ring of the largest bbox sub-polygon.
+ */
+export function reDistrictPolygonsToLabelPoints<P extends Record<string, unknown>>(
+  fc: FeatureCollection<Geometry, P>,
+): FeatureCollection<Point, P> {
+  const features: Feature<Point, P>[] = [];
+  for (const f of fc.features) {
+    const props = (f.properties ?? {}) as P;
+    const g = f.geometry;
+    if (!g) continue;
+    if (g.type === "Polygon") {
+      const ring = g.coordinates[0];
+      if (ring?.length) {
+        const c = centroidOfRingLngLat(ring);
+        features.push({ type: "Feature", properties: props, geometry: { type: "Point", coordinates: c } });
+      }
+    } else if (g.type === "MultiPolygon") {
+      let bestRing: number[][] | null = null;
+      let bestA = -1;
+      for (const poly of g.coordinates) {
+        const ring = poly[0];
+        if (!ring?.length) continue;
+        const ar = ringBBoxAreaLngLat(ring);
+        if (ar > bestA) {
+          bestA = ar;
+          bestRing = ring;
+        }
+      }
+      if (bestRing) {
+        const c = centroidOfRingLngLat(bestRing);
+        features.push({ type: "Feature", properties: props, geometry: { type: "Point", coordinates: c } });
       }
     }
   }


### PR DESCRIPTION
## Summary
Property map: filter sheet / toolbar UX, applied filter chips, MLS (RE) district overlay reliability and styling, sold-date chip behavior, and parcel hover details.

### Filter sheet and toolbar
- Prevent horizontal overflow in the filters sheet; clamp width and tighten sold/MLS grids.
- Show map **Filters** only when at least one listing type (For sale, Sold, Vacation Rentals) is selected; close the sheet when all types are cleared.
- Listing-type chips order: **For sale → Sold → Vacation Rentals** (aligned with filter sheet tabs).
- **Sold in last** presets; **Days on market** hidden on Sold tab; streamlined pool-specific copy.
- **MLS link filters:** Walk to Town / Recently renovated removed; **Pool** added (remarks heuristic via `hasPool` on LINK pins).

### Applied filter chips
- Toolbar row of removable pills for active rental / MLS constraints.
- **Default sold window:** when **Sold** is on, `soldInLast` initializes to **30 days** on mode change.
- Sold chip label: **`Sold: {preset}`** (e.g. `Sold: 30 days`). Dismissing the date chip shows a **non-dismissible** **`Sold: ~3 years`** pill matching the map feed lookback (`LINK_MAP_DEFAULT_SOLD_FEED_DAYS`, shared with `/api/map/link-listings`).

### MLS Areas overlay
- Fix overlay attach when RE GeoJSON loads before Mapbox `load` / base layers; retry on `idle` where needed.
- Overlay pill shows **MLS Areas** when that overlay is active.
- **District labels** at polygon centroids, above colored fills.
- **Fill opacity** ~30% lighter; **inter-area borders** ~50% thinner (shared zoom interpolate).

### Parcel hover popup
- **MLS Area:** full `District` name only (no `Abbrv`); **Zoning** from parcel; HTML-escaped strings; RE districts on a ref for post-load correctness.

### Testing
- `npx tsc --noEmit`
- Manual: listing types, filters sheet, chips (including sold dismiss → implicit pill), MLS overlay + labels + hover tooltip, sold pin counts vs window.

Made with [Cursor](https://cursor.com)